### PR TITLE
slt-release-finish,start: gitflow release tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Helpers to building, testing, staging, and releasing modules at StrongLoop.
 
 ## Current commands
 
+ * `slt-release`
+   * Runs the strongloop/npm package variant of git flow
  * `slt-changelog`
    * Writes changelog
    * Requires Ruby 1.9+
@@ -13,6 +15,22 @@ Helpers to building, testing, staging, and releasing modules at StrongLoop.
    * Requres Ruby 1.9+
  * `slt`
    * lint, CLA boilerplate, package version manipulation, others...
+
+### slt-release
+
+```
+usage: slt-release [-hun] VERSION [FROM]
+
+Options:
+  h   print this helpful message
+  u   update the origin with a git push
+  n   publish the package to npmjs.org
+
+VERSION must be specified and should be `x.y.z` (with no leading `v`).
+
+FROM is optional, and is where the release branch should start from, the
+default is origin/master.
+```
 
 ### slt-changelog
 

--- a/bin/slt-release-finish.sh
+++ b/bin/slt-release-finish.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+
+USAGE="usage: slt-release-finish VERSION"
+
+if [ "$1" = "" ]; then
+  echo $USAGE
+  exit 1
+fi
+
+set -e
+
+V=${1:?version is mandatory}
+
+echo "Merging release branch to production and tag as $V"
+git checkout production
+git pull --ff-only origin production
+git merge --no-ff --no-edit release/"$V"
+git tag -a "v$V" -m "$V"
+# Need -D because master has not been pushed to origin/master. If we auto-push,
+# we can change it to --delete, but I think it does no harm to use -D.
+git branch -D release/"$V"
+
+echo "Merging production branch to master"
+git checkout master
+git pull --ff-only origin master
+git merge --no-ff --no-edit "$V"
+git checkout production
+
+if [ "$SLT_RELEASE_UPDATE" = "y" ]
+then
+  echo "Pushing tag $V and branches production and master to origin"
+  git push origin $V:$V production:production master:master
+else
+  echo "Push tag $V and branches production and master to origin when ready:"
+  echo "  git push origin $V:$V production:production master:master"
+fi
+
+if [ "$SLT_RELEASE_PUBLISH" = "y" ]
+then
+  echo "Publishing to npmjs.org"
+  npm publish
+  git checkout master
+else
+  echo "Publish to npmjs.org when ready:"
+  echo "  npm publish"
+fi

--- a/bin/slt-release-start.sh
+++ b/bin/slt-release-start.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+USAGE="usage: slt-release-start VERSION [FROM]"
+
+if [ "$1" = "" ]; then
+  echo $USAGE
+  exit 1
+fi
+
+set -e
+
+V=${1:?version is mandatory}
+H=${2:-origin/master}
+
+echo "Creating release branch `release/$V` from $H"
+git checkout -b release/"$V" "$H"
+
+echo "Updating CHANGES.md"
+slt-changelog --version "$V"
+
+echo "Updating package version to $V"
+# XXX(sam) will need to use some other tool, this command fails when version
+# is not changed... and our staging flow sometimes requires the package version
+# to be incremented on master along with the commit that introduced a new
+# feature
+npm version --git-tag-version=false "$V" || /bin/true
+
+echo "Committing package and CHANGES for v$V"
+git add package.json CHANGES.md
+# XXX(sam) commit body should be CHANGES for this release
+git commit -m "v$V"

--- a/bin/slt-release.sh
+++ b/bin/slt-release.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+
+exec << "___"
+usage: slt-release [-hun] VERSION [FROM]
+
+Options:
+  h   print this helpful message
+  u   update the origin with a git push
+  n   publish the package to npmjs.org
+
+VERSION must be specified and should be `x.y.z` (with no leading `v`).
+
+FROM is optional, and is where the release branch should start from, the
+default is origin/master.
+___
+
+while getopts hnu f
+do
+  case $f in
+    h)  cat; exit 0;;
+    u)  export SLT_RELEASE_UPDATE=y;;
+    n)  export SLT_RELEASE_PUBLISH=y;;
+  esac
+done
+shift `expr $OPTIND - 1` "$@"
+
+if [ "$1" = "" ]
+then
+  echo "Missing version, try \`slt-release -h\` for help."
+  exit 1
+fi
+
+set -e
+
+slt-release-start "$@"
+slt-release-finish "$@"

--- a/package.json
+++ b/package.json
@@ -29,6 +29,9 @@
   },
   "bin": {
     "slt": "bin/slt.js",
+    "slt-release": "bin/slt-release.sh",
+    "slt-release-finish": "bin/slt-release-finish.sh",
+    "slt-release-start": "bin/slt-release-start.sh",
     "slt-stage": "bin/slt-stage.rb",
     "slt-changelog": "bin/slt-changelog.rb"
   },


### PR DESCRIPTION
These tools implement the gitflow release process, auto-generating the
changelog and setting the npm package version.

/to @rmg @bajtos 

I needed to cut a strong-supervisor release that was not from the head of origin/master, unsupported by hubflow, so I finally replaced it with a few lines of shell scripts, as threatened.
