### PR TITLE
Remove unused second argument to shift

### DIFF
--- a/bin/slt-release.sh
+++ b/bin/slt-release.sh
@@ -22,7 +22,7 @@ do
     n)  export SLT_RELEASE_PUBLISH=y;;
   esac
 done
-shift `expr $OPTIND - 1` "$@"
+shift `expr $OPTIND - 1`
 
 if [ "$1" = "" ]
 then


### PR DESCRIPTION
It came from the man page example from getopts, but seems to be an
error, shift doesn't take another argument.

Fix https://github.com/strongloop/strong-tools/issues/10
