### PR TITLE
slt-release-start: fetch origin before branching

### DIFF
--- a/bin/slt-release-start.sh
+++ b/bin/slt-release-start.sh
@@ -13,6 +13,7 @@ V=${1:?version is mandatory}
 H=${2:-origin/master}
 
 echo "Creating release branch 'release/$V' from $H"
+git fetch origin
 git checkout -b release/"$V" "$H"
 
 echo "Updating CHANGES.md"


### PR DESCRIPTION
Not updating, especially in combination with the auto-publish and
auto-push, can be bad.
