### PR TITLE
slt-release: change -n to -p, so `-up` updates

### DIFF
--- a/bin/slt-release.sh
+++ b/bin/slt-release.sh
@@ -6,12 +6,21 @@ usage: slt-release [-hun] VERSION [FROM]
 Options:
   h   print this helpful message
   u   update the origin with a git push
-  n   publish the package to npmjs.org
+  p   publish the package to npmjs.org
 
 VERSION must be specified and should be `x.y.z` (with no leading `v`).
 
 FROM is optional, and is where the release branch should start from, the
 default is origin/master.
+
+Typical usage, if you want to examine the results before updating github
+and npmjs.org:
+
+  slt-release 1.2.3
+
+And if you are comfortable that the results should be pushed and published:
+
+  slt-release -up 1.2.3
 ___
 
 while getopts hnu f
@@ -19,7 +28,8 @@ do
   case $f in
     h)  cat; exit 0;;
     u)  export SLT_RELEASE_UPDATE=y;;
-    n)  export SLT_RELEASE_PUBLISH=y;;
+    n)  export SLT_RELEASE_PUBLISH=y;; # For backwards compatibility
+    p)  export SLT_RELEASE_PUBLISH=y;;
   esac
 done
 shift `expr $OPTIND - 1`


### PR DESCRIPTION
It should be easier to remember the options like this.

Originally I tried not to use `p`, because I thought it would be unclear whether it meant `git Push` or `npm Publish`, but now I can never remember what the option names are... I think that `-up` combination is pretty easy, though.

What think you, @bajtos and @rmg ?
