### PR TITLE
Support divergent changelogs on release branches

### DIFF
--- a/bin/slt-changelog.rb
+++ b/bin/slt-changelog.rb
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
 
+require 'date'
 require 'optparse'
 require 'pathname'
 
@@ -9,6 +10,9 @@ class GitRepo
     @sha1 = Hash.new do |cache, ref|
       cache[ref] = `#{git} rev-list -n 1 #{ref}`.strip
     end
+    @date_of = Hash.new do |cache, ref|
+      cache[ref] = DateTime.parse(`#{git} log --date=iso-strict --format="%ad" -n1 '#{ref}'`.strip) #.utc
+    end
   end
 
   def changelog(next_release=false)
@@ -17,30 +21,35 @@ class GitRepo
     base = "#{git} log --full-history --date-order --pretty='format:%s (%an)'"
     releases = []
     tags = tags_by_topo
-    return '' if tags.empty?
-    release_heading = `#{git} log --date=short --format="%ad" -n1 '#{tags.first}'`.strip + ", Version #{clean_version(tags.first)}"
+
+    # First release doesn't have a full changelog
+    if tags.empty?
+      release_heading = "#{Time.now.utc.strftime("%Y-%m-%d")}, Version #{clean_version(next_release || '0.0.0')}"
+    else
+      release_heading = "#{date_of(tags.first).strftime("%Y-%m-%d")}, Version #{clean_version(tags.first)}"
+    end
     release = []
     release << " * First release!"
     release << "#{release_heading}\n#{'='*release_heading.length}\n"
     releases << release.reverse.join("\n")
+
+    # 2nd, 3rd, etc. releases have changes between them
     tags.each_cons(2) do |a,b|
-      release_heading = `#{git} log --date=short --format="%ad" -n1 '#{b}'`.strip + ", Version #{clean_version(b)}"
+      release_heading = "#{date_of(b).strftime("%Y-%m-%d")}, Version #{clean_version(b)}"
       release = []
       release << changelog_filter(`#{base} '#{sha1(a)}..#{sha1(b)}'`)
       next if release.empty?
       release << "#{release_heading}\n#{'='*release_heading.length}\n"
       releases << release.reverse.join("\n")
     end
-    if next_release
-      last_release = `#{git} rev-list --tags --max-count=1`.strip
-      if sha1('HEAD') != sha1(last_release) and not last_release.empty?
-        release_tag = `#{git} tag --points-at=#{last_release}`.strip
-        release_heading = "#{Time.now.utc.strftime("%Y-%m-%d")}, Version #{clean_version(next_release)}"
-        release = []
-        release << changelog_filter(`#{base} #{last_release}..`)
-        release << "#{release_heading}\n#{'='*release_heading.length}\n" unless release.empty?
-        releases << release.reverse.join("\n") unless release.empty?
-      end
+
+    # Release we are pretending HEAD is
+    if next_release and tags.length > 0 and sha1('HEAD') != sha1(tags.last)
+      release_heading = "#{Time.now.utc.strftime("%Y-%m-%d")}, Version #{clean_version(next_release)}"
+      release = []
+      release << changelog_filter(`#{base} #{sha1(tags.last)}..`)
+      release << "#{release_heading}\n#{'='*release_heading.length}\n" unless release.empty?
+      releases << release.reverse.join("\n") unless release.empty?
     end
     releases.reverse.join("\n\n") + "\n"
   end
@@ -94,6 +103,14 @@ class GitRepo
       nil
     else
       @sha1[ref]
+    end
+  end
+
+  def date_of(ref)
+    if ref.nil? or ref.empty?
+      nil
+    else
+      @date_of[sha1(ref)]
     end
   end
 

--- a/bin/slt-changelog.rb
+++ b/bin/slt-changelog.rb
@@ -65,19 +65,16 @@ class GitRepo
     # --date-order: order commits by date, not topological order
     base = "#{git} log --full-history --date-order --pretty='format:%s (%an)'"
     last_release = sha1(tags_by_topo.last)
-    if last_release.empty?
-      last_release = `git rev-list --max-parents=0 HEAD`.strip
-    end
-    if sha1('HEAD') != sha1(last_release)
-      release = []
+    release = []
+    if last_release.nil?
+      release << ' * First release!'
+    elsif sha1('HEAD') != sha1(last_release)
       release << changelog_filter(`#{base} #{last_release}..`)
-      if version
-        release << "#{clean_version(version)}\n"
-      end
-      release.reverse.join("\n")
-    else
-      ''
     end
+    if version
+      release << "#{clean_version(version)}\n"
+    end
+    release.reverse.join("\n")
   end
 
   def changelog_filter(log)


### PR DESCRIPTION
I've tested it with repos that have never been released, where HEAD == latest release, and multiple branches of loopback and loopback-boot, and in all cases the result is a drastic improvement in accuracy and consistency.

@bajtos this one is for you, it's the real fix for #22 