### PR TITLE
Add fix-license command

### DIFF
--- a/bin/slt.js
+++ b/bin/slt.js
@@ -20,13 +20,16 @@ function usage($0, p) {
   p('Usage: %s <CMD> [PKG]', $0);
   p('');
   p('Commands:');
-  p('  lint      Perform a simple linting of the given package.json');
-  p('  cla       Create or verify contribution guidelines');
-  p('  info      Display metadata about package');
-  p('  version   Version manipulation');
-  p('  semver    Wrapper for semver command from semver package');
-  p('  help      Print this usage guide');
+  p('  lint        Perform a simple linting of the given package.json');
+  p('  cla         Create or verify contribution guidelines');
+  p('  license     Set package licensing');
+  p('  info        Display metadata about package');
+  p('  version     Version manipulation');
+  p('  semver      Wrapper for semver command from semver package');
+  p('  help        Print this usage guide');
   p('');
+  p('Confirm license changes are acceptable with:');
+  p('    git diff -M --cached -w --ignore-blank-lines');
 }
 
 function defaultCLI(fn, pkgPath) {

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ var wrapped = require('./lib/wrapped');
 
 module.exports = {
   lint: require('./lib/lint'),
+  'license': require('./lib/license'),
   cla: require('./lib/cla'),
   Project: require('./lib/project'),
   info: require('./lib/info'),

--- a/lib/DUAL_ARTISTIC.tpl
+++ b/lib/DUAL_ARTISTIC.tpl
@@ -1,0 +1,7 @@
+<%= name %> uses a dual license model.
+
+You may use this library under the terms of the [Artistic 2.0 license][],
+or under the terms of the [StrongLoop Subscription Agreement][].
+
+[Artistic 2.0 license]: http://opensource.org/licenses/Artistic-2.0
+[StrongLoop Subscription Agreement]: http://strongloop.com/license

--- a/lib/DUAL_MIT.tpl
+++ b/lib/DUAL_MIT.tpl
@@ -1,0 +1,311 @@
+Copyright (c) 2013-2015 StrongLoop, Inc.
+
+<%= name %> uses a 'dual license' model. Users may use
+<%= name %> under the terms of the MIT license, or under the
+StrongLoop License. The text of both is included below.
+
+MIT license
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+StrongLoop License
+
+STRONGLOOP SUBSCRIPTION AGREEMENT
+PLEASE READ THIS AGREEMENT CAREFULLY BEFORE YOU AGREE TO THESE TERMS.  IF YOU
+ARE ACTING ON BEHALF OF AN ENTITY, THEN YOU REPRESENT THAT YOU HAVE THE
+AUTHORITY TO ENTER INTO THIS AGREEMENT ON BEHALF OF THAT ENTITY.  IF YOU DO NOT
+AGREE TO THESE TERMS, YOU SHOULD NOT AGREE TO THE TERMS OF THIS AGREEMENT OR
+INSTALL OR USE THE SOFTWARE.
+This StrongLoop Subscription Agreement ("Agreement") is made by and between
+StrongLoop, Inc. ("StrongLoop") with its principal place of business at 107 S.
+B St, Suite 220, San Mateo, CA 94401 and the person or entity entering into this
+Agreement ("Customer").  The effective date ("Effective Date") of this Agreement
+is the date Customer agrees to these terms or installs or uses the Software (as
+defined below).  This Agreement applies to Customer's use of the Software but it
+shall be superseded by any signed agreement between you and StrongLoop
+concerning the Software.
+1. Subscriptions and Licenses.
+1.1 Subscriptions.  StrongLoop offers five different subscription levels to its
+customers, each as more particularly described on StrongLoop's website located
+at www.strongloop.com (the "StrongLoop Site"):  (1) Free; (2) Developer; (3)
+Professional; (4) Gold; and (5) Platinum.  The actual subscription level
+applicable to Customer (the "Subscription") will be specified in the purchase
+order that Customer issues to StrongLoop.  This Agreement applies to Customer
+regardless of the level of the Subscription selected by Customer and whether or
+not Customer upgrades or downgrades its Subscription.  StrongLoop hereby agrees
+to provide the services as described on the StrongLoop Site for each
+Subscription level during the term for which Customer has purchased the
+applicable Subscription, subject to Customer paying the fees applicable to the
+Subscription level purchased, if any (the "Subscription Fees").  StrongLoop may
+modify the services to be provided under any Subscription upon notice to
+Customer.
+1.2 License Grant.  Subject to the terms and conditions of this Agreement,
+StrongLoop grants to Customer, during the Subscription Term (as defined in
+Section 7.1 (Term and Termination) of this Agreement, a limited, non-exclusive,
+non-transferable right and license, to install and use the  StrongLoop Suite
+software (the "Software") and the documentation made available electronically as
+part of the Software (the "Documentation"), either of which may be modified
+during the Term (as defined in Section 7.1 below), solely for development,
+production and commercial purposes so long as Customer is using the Software to
+run only one process on a given operating system at a time.  This Agreement,
+including but not limited to the license and restrictions contained herein,
+apply to Customer regardless of whether Customer accesses the Software via
+download from the StrongLoop Site or through a third-party website or service,
+even if Customer acquired the Software prior to agreeing to this Agreement.
+1.3 License Restrictions.  Customer shall not itself, or through any parent,
+subsidiary, affiliate, agent or other third party:
+      1.3.1 sell, lease, license, distribute, sublicense or otherwise transfer
+      in whole or in part, any Software or the Documentation to a third party;
+      or
+      1.3.2 decompile, disassemble, translate, reverse engineer or otherwise
+      attempt to derive source code from the Software, in whole or in part, nor
+      shall Customer use any mechanical, electronic or other method to trace,
+      decompile, disassemble, or identify the source code of the Software or
+      encourage others to do so, except to the limited extent, if any, that
+      applicable law permits such acts notwithstanding any contractual
+      prohibitions, provided, however, before Customer exercises any rights that
+      Customer believes to be entitled to based on mandatory law, Customer shall
+      provide StrongLoop with thirty (30) days prior written notice and provide
+      all reasonably requested information to allow StrongLoop to assess
+      Customer's claim and, at StrongLoop's sole discretion, to provide
+      alternatives that reduce any adverse impact on StrongLoop's intellectual
+      property or other rights; or
+      1.3.3 allow access or permit use of the Software by any users other than
+      Customer's employees or authorized third-party contractors who are
+      providing services to Customer and agree in writing to abide by the terms
+      of this Agreement, provided further that Customer shall be liable for any
+      failure by such employees and third-party contractors to comply with the
+      terms of this Agreement and no usage restrictions, if any, shall be
+      exceeded; or
+      1.3.4 create, develop, license, install, use, or deploy any third party
+      software or services to circumvent or provide access, permissions or
+      rights which violate the license keys embedded within the Software; or
+      1.3.5 modify or create derivative works based upon the Software or
+      Documentation; or disclose the results of any benchmark test of the
+      Software to any third party without StrongLoop's prior written approval;
+      or
+      1.3.6 change any proprietary rights notices which appear in the Software
+      or Documentation; or
+      1.3.7 use the Software as part of a time sharing or service bureau
+      purposes or in any other resale capacity.
+1.4 Third-Party Software.  The Software may include individual certain software
+that is owned by third parties, including individual open source software
+components (the "Third-Party Software"), each of which has its own copyright and
+its own applicable license conditions.  Such third-party software is licensed to
+Customer under the terms of the applicable third-party licenses and/or copyright
+notices that can be found in the LICENSES file, the Documentation or other
+materials accompanying the Software, except that Sections 5 (Warranty
+Disclaimer) and 6 (Limitation of Liability) also govern Customer's use of the
+third-party software.  Customer agrees to comply with the terms and conditions
+of the relevant third-party software licenses.
+2. Support Services.  StrongLoop has no obligation to provide any support for
+the Software other than the support services specifically described on the
+StrongLoop Site for the Subscription level procured by Customer.  However,
+StrongLoop has endeavored to establish a community of users of the Software who
+have provided their own feedback, hints and advice regarding their experiences
+in using the Software.  You can find that community and user feedback on the
+StrongLoop Site.  The use of any information, content or other materials from,
+contained in or on the StrongLoop Site are subject to the StrongLoop website
+terms of use located here http://www.strongloop.com/terms-of-service.
+3. Confidentiality.  For purposes of this Agreement, "Confidential Information"
+means any and all information or proprietary materials (in every form and media)
+not generally known in the relevant trade or industry and which has been or is
+hereafter disclosed or made available by StrongLoop to Customer in connection
+with the transactions contemplated under this Agreement, including (i) all trade
+secrets, (ii) existing or contemplated Software, services, designs, technology,
+processes, technical data, engineering, techniques, methodologies and concepts
+and any related information, and (iii) information relating to business plans,
+sales or marketing methods and customer lists or requirements.  For a period of
+five (5) years from the date of disclosure of the applicable Confidential
+Information, Customer shall (i) hold the Confidential Information in trust and
+confidence and avoid the disclosure or release thereof to any other person or
+entity by using the same degree of care as it uses to avoid unauthorized use,
+disclosure, or dissemination of its own Confidential Information of a similar
+nature, but not less than reasonable care, and (ii) not use the Confidential
+Information for any purpose whatsoever except as expressly contemplated under
+this Agreement; provided that, to the extent the Confidential Information
+constitutes a trade secret under law, Customer agrees to protect such
+information for so long as it qualifies as a trade secret under applicable law.
+Customer shall disclose the Confidential Information only to those of its
+employees and contractors having a need to know such Confidential Information
+and shall take all reasonable precautions to ensure that such employees and
+contractors comply with the provisions of this Section.  The obligations of
+Customer under this Section shall not apply to information that Customer can
+demonstrate (i) was in its possession at the time of disclosure and without
+restriction as to confidentiality, (ii) at the time of disclosure is generally
+available to the public or after disclosure becomes generally available to the
+public through no breach of agreement or other wrongful act by Customer, (iii)
+has been received from a third party without restriction on disclosure and
+without breach of agreement by Customer, or (iv) is independently developed by
+Customer without regard to the Confidential Information.  In addition, Customer
+may disclose Confidential Information as required to comply with binding orders
+of governmental entities that have jurisdiction over it; provided that Customer
+gives StrongLoop reasonable written notice to allow StrongLoop to seek a
+protective order or other appropriate remedy, discloses only such Confidential
+Information as is required by the governmental entity, and uses commercially
+reasonable efforts to obtain confidential treatment for any Confidential
+Information disclosed.  Notwithstanding the above, Customer agrees that
+StrongLoop, its employees and agents shall be free to use and employ their
+general skills, know-how, and expertise, and to use, disclose, and employ any
+generalized ideas, concepts, know-how, methods, techniques or skills gained or
+learned during the Term or thereafter.
+4. Ownership.  StrongLoop shall retain all intellectual property and proprietary
+rights in the Software, Documentation, and related works, including but not
+limited to any derivative work of the foregoing and StrongLoop's licensors shall
+retain all intellectual property and proprietary rights in any Third-Party
+Software that may be provided with or as a part of the Software.  Customer shall
+do nothing inconsistent with StrongLoop's or its licensors' title to the
+Software and the intellectual property rights embodied therein, including, but
+not limited to, transferring, loaning, selling, assigning, pledging, or
+otherwise disposing, encumbering, or suffering a lien or encumbrance upon or
+against any interest in the Software.  The Software (including any Third-Party
+Software) contain copyrighted material, trade secrets and other proprietary
+material of StrongLoop and/or its licensors.
+5. Warranty Disclaimer.  THE SOFTWARE (INCLUDING ANY THIRD-PARTY SOFTWARE) AND
+DOCUMENTATION MADE AVAILABLE TO CUSTOMER ARE PROVIDED "AS-IS" AND STRONGLOOP,
+ON BEHALF OF ITSELF AND ITS LICENSORS, EXPRESSLY DISCLAIMS ALL WARRANTIES OF ANY
+KIND, EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, ANY IMPLIED WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, TITLE,
+PERFORMANCE, AND ACCURACY AND ANY IMPLIED WARRANTIES ARISING FROM STATUTE,
+COURSE OF DEALING, COURSE OF PERFORMANCE, OR USAGE OF TRADE.  STRONGLOOP DOES
+NOT WARRANT THAT THE OPERATION OF THE SOFTWARE WILL BE UNINTERRUPTED OR
+ERROR-FREE, THAT DEFECTS IN THE SOFTWARE WILL BE CORRECTED OR THAT THE SOFTWARE
+WILL PROVIDE OR ENSURE ANY PARTICULAR RESULTS OR OUTCOME.  NO ORAL OR WRITTEN
+INFORMATION OR ADVICE GIVEN BY STRONGLOOP OR ITS AUTHORIZED REPRESENTATIVES
+SHALL CREATE A WARRANTY OR IN ANY WAY INCREASE THE SCOPE OF THIS WARRANTY.
+STRONGLOOP IS NOT OBLIGATED TO PROVIDE CUSTOMER WITH UPGRADES TO THE SOFTWARE,
+BUT MAY ELECT TO DO SO IN ITS SOLE DISCRETION. SOME JURISDICTIONS DO NOT ALLOW
+THE EXCLUSION OF IMPLIED WARRANTIES, SO THE ABOVE EXCLUSION MAY NOT APPLY TO
+CUSTOMER.WITHOUT LIMITING THE GENERALITY OF THE FOREGOING DISCLAIMER, THE
+SOFTWARE AND DOCUMENTATION ARE NOT DESIGNED, MANUFACTURED OR INTENDED FOR USE IN
+THE PLANNING, CONSTRUCTION, MAINTENANCE, CONTROL, OR DIRECT OPERATION OF NUCLEAR
+FACILITIES, AIRCRAFT NAVIGATION, CONTROL OR COMMUNICATION SYSTEMS, WEAPONS
+SYSTEMS, OR DIRECT LIFE SUPPORT SYSTEMS.
+6. Limitation of Liability.
+      6.1 Exclusion of Liability.  IN NO EVENT WILL STRONGLOOP OR ITS LICENSORS
+      BE LIABLE UNDER THIS AGREEMENT FOR ANY INDIRECT, RELIANCE, PUNITIVE,
+      CONSEQUENTIAL, SPECIAL, EXEMPLARY, OR INCIDENTAL DAMAGES OF ANY KIND AND
+      HOWEVER CAUSED (INCLUDING, WITHOUT LIMITATION, DAMAGES FOR LOSS OF
+      BUSINESS PROFITS, BUSINESS INTERRUPTION, LOSS OF BUSINESS INFORMATION AND
+      THE LIKE), EVEN IF STRONGLOOP HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+      DAMAGES.  CUSTOMER BEARS FULL RESPONSIBILITY FOR USE OF THE SOFTWARE AND
+      THE SUBSCRIPTION AND STRONGLOOP DOES NOT GUARANTEE THAT THE USE OF THE
+      SOFTWARE AND SUBSCRIPTION WILL ENSURE THAT CUSTOMER'S NETWORK WILL BE
+      AVAILABLE, SECURE, MONITORED OR PROTECTED AGAINST ANY DOWNTIME, DENIAL OF
+      SERVICE ATTACKS, SECUITY BREACHES, HACKERS AND THE LIKE.  IN NO EVENT WILL
+      STRONGLOOP'S CUMULATIVE LIABILITY FOR ANY DAMAGES, LOSSES AND CAUSES OF
+      ACTION (WHETHER IN CONTRACT, TORT, INCLUDING NEGLIGENCE, OR OTHERWISE)
+      ARISING OUT OF OR RELATED TO THIS AGREEMENT EXCEED THE GREATER OF ONE
+      HUNDRED DOLLARS (US$100) OR THE TOTAL SUBSCRIPTION FEES PAID BY CUSTOMER
+      TO STRONGLOOP IN THE TWELVE (12) MONTHS PRECEDING THE DATE THE CLAIM
+      ARISES.
+      6.2 Limitation of Damages.  IN NO EVENT WILL STRONGLOOP'S LICENSORS HAVE
+      ANY LIABILITY FOR ANY CLAIM ARISING IN CONNECTION WITH THIS AGREEMENT.
+      THE PROVISIONS OF THIS SECTION 6 ALLOCATE RISKS UNDER THIS AGREEMENT
+      BETWEEN CUSTOMER, STRONGLOOP AND STRONGLOOP'S SUPPLIERS.  THE FOREGOING
+      LIMITATIONS, EXCLUSIONS AND DISCLAIMERS APPLY TO THE MAXIMUM EXTENT
+      PERMITTED BY APPLICABLE LAW, EVEN IF ANY REMEDY FAILS IN ITS ESSENTIAL
+      PURPOSE.
+      6.3 Failure of Essential Purpose.  THE PARTIES AGREE THAT THESE
+      LIMITATIONS SHALL APPLY EVEN IF THIS AGREEMENT OR ANY LIMITED REMEDY
+      SPECIFIED HEREIN IS FOUND TO HAVE FAILED OF ITS ESSENTIAL PURPOSE.
+      6.4 Allocation of Risk.  The sections on limitation of liability and
+      disclaimer of warranties allocate the risks in the Agreement between the
+      parties.  This allocation is an essential element of the basis of the
+      bargain between the parties.
+7. Term and Termination.
+7.1 This Agreement shall commence on the Effective Date and continue for so long
+as Customer has a valid Subscription and is current on the payment of any
+Subscription Fees required to be paid for that Subscription (the "Subscription
+Term").  Either party may terminate this Agreement immediately upon written
+notice to the other party, and the Subscription and licenses granted hereunder
+automatically terminate upon the termination of this Agreement.  This Agreement
+will terminate immediately without notice from StrongLoop if Customer fails to
+comply with or otherwise breaches any provision of this Agreement.
+7.2 All Sections other than Section 1.1 (Subscriptions) and 1.2 (Licenses) shall
+survive the expiration or termination of this Agreement.
+8. Subscription Fees and Payments.  StrongLoop, Customer agrees to pay
+StrongLoop the Subscription Fees as described on the StrongLoop Site for the
+Subscription purchased unless a different amount has been agreed to in a
+separate agreement between Customer and StrongLoop.  In addition, Customer shall
+pay all sales, use, value added, withholding, excise taxes and other tax, duty,
+custom and similar fees levied upon the delivery or use of the Software and the
+Subscriptions described in this Agreement.  Fees shall be invoiced in full upon
+StrongLoop's acceptance of Customer's purchase order for the Subscription.  All
+invoices shall be paid in US dollars and are due upon receipt and shall be paid
+within thirty (30) days. Payments shall be made without right of set-off or
+chargeback. If Customer does not pay the invoices when due, StrongLoop may
+charge interest at one percent (1%) per month or the highest rate permitted by
+law, whichever is lower, on the unpaid balance from the original due date. If
+Customer fails to pay fees in accordance with this Section, StrongLoop may
+suspend fulfilling its obligations under this Agreement (including but not
+limited to suspending the services under the Subscription) until payment is
+received by StrongLoop.  If any applicable law requires Customer to withhold
+amounts from any payments to StrongLoop under this Agreement, (a) Customer shall
+effect such withholding, remit such amounts to the appropriate taxing
+authorities and promptly furnish StrongLoop with tax receipts evidencing the
+payments of such amounts and (b) the sum payable by Customer upon which the
+deduction or withholding is based shall be increased to the extent necessary to
+ensure that, after such deduction or withholding, StrongLoop receives and
+retains, free from liability for such deduction or withholding, a net amount
+equal to the amount StrongLoop would have received and retained absent the
+required deduction or withholding.
+9. General.
+9.1 Compliance with Laws.  Customer shall abide by all local, state, federal and
+international laws, rules, regulations and orders applying to Customer's use of
+the Software, including, without limitation, the laws and regulations of the
+United States that may restrict the export and re-export of certain commodities
+and technical data of United States origin, including the Software.  Customer
+agrees that it will not export or re-export the Software without the appropriate
+United States or foreign government licenses.
+9.2 Entire Agreement.  This Agreement constitutes the entire agreement between
+the parties concerning the subject matter hereof.  This Agreement supersedes all
+prior or contemporaneous discussions, proposals and agreements between the
+parties relating to the subject matter hereof.  No amendment, modification or
+waiver of any provision of this Agreement shall be effective unless in writing
+and signed by both parties.  Any additional or different terms on any purchase
+orders issued by Customer to StrongLoop shall not be binding on either party,
+are hereby rejected by StrongLoop and void.
+9.3 Severability.  If any provision of this Agreement is held to be invalid or
+unenforceable, the remaining portions shall remain in full force and effect and
+such provision shall be enforced to the maximum extent possible so as to effect
+the intent of the parties and shall be reformed to the extent necessary to make
+such provision valid and enforceable.
+9.4 Waiver.  No waiver of rights by either party may be implied from any actions
+or failures to enforce rights under this Agreement.
+9.5 Force Majeure.  Neither party shall be liable to the other for any delay or
+failure to perform due to causes beyond its reasonable control (excluding
+payment of monies due).
+9.6 No Third Party Beneficiaries.  Unless otherwise specifically stated, the
+terms of this Agreement are intended to be and are solely for the benefit of
+StrongLoop and Customer and do not create any right in favor of any third party.
+9.7 Governing Law and Jurisdiction.  This Agreement shall be governed by the
+laws of the State of California, without reference to the principles of
+conflicts of law.  The provisions of the Uniform Computerized Information
+Transaction Act and United Nations Convention on Contracts for the International
+Sale of Goods shall not apply to this Agreement.  The parties shall attempt to
+resolve any dispute related to this Agreement informally, initially through
+their respective management, and then by non-binding mediation in San Francisco
+County, California.  Any litigation related to this Agreement shall be brought
+in the state or federal courts located in San Francisco County, California, and
+only in those courts and each party irrevocably waives any objections to such
+venue.
+9.8 Notices.  All notices must be in writing and shall be effective three (3)
+days after the date sent to the other party's headquarters, Attention Chief
+Financial Officer.

--- a/lib/STRONGLOOP.tpl
+++ b/lib/STRONGLOOP.tpl
@@ -1,0 +1,323 @@
+Copyright (c) 2013-2015 StrongLoop, Inc.
+
+StrongLoop License
+
+STRONGLOOP SUBSCRIPTION AGREEMENT
+
+PLEASE READ THIS AGREEMENT CAREFULLY BEFORE YOU AGREE TO THESE TERMS.  IF YOU
+ARE ACTING ON BEHALF OF AN ENTITY, THEN YOU REPRESENT THAT YOU HAVE THE
+AUTHORITY TO ENTER INTO THIS AGREEMENT ON BEHALF OF THAT ENTITY.  IF YOU DO NOT
+AGREE TO THESE TERMS, YOU SHOULD NOT AGREE TO THE TERMS OF THIS AGREEMENT OR
+INSTALL OR USE THE SOFTWARE.
+
+This StrongLoop Subscription Agreement ("Agreement") is made by and between
+StrongLoop, Inc. ("StrongLoop") with its principal place of business at 107 S.
+B St, Suite 220, San Mateo, CA 94401 and the person or entity entering into this
+Agreement ("Customer").  The effective date ("Effective Date") of this Agreement
+is the date Customer agrees to these terms or installs or uses the Software (as
+defined below).  This Agreement applies to Customer's use of the Software but it
+shall be superseded by any signed agreement between you and StrongLoop
+concerning the Software.
+
+1. Subscriptions and Licenses.
+
+1.1 Subscriptions.  StrongLoop offers five different subscription levels to its
+customers, each as more particularly described on StrongLoop's website located
+at www.strongloop.com (the "StrongLoop Site"):  (1) Free; (2) Developer; (3)
+Professional; (4) Gold; and (5) Platinum.  The actual subscription level
+applicable to Customer (the "Subscription") will be specified in the purchase
+order that Customer issues to StrongLoop.  This Agreement applies to Customer
+regardless of the level of the Subscription selected by Customer and whether or
+not Customer upgrades or downgrades its Subscription.  StrongLoop hereby agrees
+to provide the services as described on the StrongLoop Site for each
+Subscription level during the term for which Customer has purchased the
+applicable Subscription, subject to Customer paying the fees applicable to the
+Subscription level purchased, if any (the "Subscription Fees").  StrongLoop may
+modify the services to be provided under any Subscription upon notice to
+Customer.
+
+1.2 License Grant.  Subject to the terms and conditions of this Agreement,
+StrongLoop grants to Customer, during the Subscription Term (as defined in
+Section 7.1 (Term and Termination) of this Agreement, a limited, non-exclusive,
+non-transferable right and license, to install and use the  StrongLoop Suite
+software (the "Software") and the documentation made available electronically as
+part of the Software (the "Documentation"), either of which may be modified
+during the Term (as defined in Section 7.1 below), solely for development,
+production and commercial purposes so long as Customer is using the Software to
+run only one process on a given operating system at a time.  This Agreement,
+including but not limited to the license and restrictions contained herein,
+apply to Customer regardless of whether Customer accesses the Software via
+download from the StrongLoop Site or through a third-party website or service,
+even if Customer acquired the Software prior to agreeing to this Agreement.
+
+1.3 License Restrictions.  Customer shall not itself, or through any parent,
+subsidiary, affiliate, agent or other third party:
+
+1.3.1 sell, lease, license, distribute, sublicense or otherwise transfer
+in whole or in part, any Software or the Documentation to a third party;
+or
+
+1.3.2 decompile, disassemble, translate, reverse engineer or otherwise
+attempt to derive source code from the Software, in whole or in part, nor
+shall Customer use any mechanical, electronic or other method to trace,
+decompile, disassemble, or identify the source code of the Software or
+encourage others to do so, except to the limited extent, if any, that
+applicable law permits such acts notwithstanding any contractual
+prohibitions, provided, however, before Customer exercises any rights that
+Customer believes to be entitled to based on mandatory law, Customer shall
+provide StrongLoop with thirty (30) days prior written notice and provide
+all reasonably requested information to allow StrongLoop to assess
+Customer's claim and, at StrongLoop's sole discretion, to provide
+alternatives that reduce any adverse impact on StrongLoop's intellectual
+property or other rights; or
+
+1.3.3 allow access or permit use of the Software by any users other than
+Customer's employees or authorized third-party contractors who are
+providing services to Customer and agree in writing to abide by the terms
+of this Agreement, provided further that Customer shall be liable for any
+failure by such employees and third-party contractors to comply with the
+terms of this Agreement and no usage restrictions, if any, shall be
+exceeded; or
+
+1.3.4 create, develop, license, install, use, or deploy any third party
+software or services to circumvent or provide access, permissions or
+rights which violate the license keys embedded within the Software; or
+
+1.3.5 modify or create derivative works based upon the Software or
+Documentation; or disclose the results of any benchmark test of the
+Software to any third party without StrongLoop's prior written approval;
+or
+
+1.3.6 change any proprietary rights notices which appear in the Software
+or Documentation; or
+
+1.3.7 use the Software as part of a time sharing or service bureau
+purposes or in any other resale capacity.
+
+1.4 Third-Party Software.  The Software may include individual certain software
+that is owned by third parties, including individual open source software
+components (the "Third-Party Software"), each of which has its own copyright and
+its own applicable license conditions.  Such third-party software is licensed to
+Customer under the terms of the applicable third-party licenses and/or copyright
+notices that can be found in the LICENSES file, the Documentation or other
+materials accompanying the Software, except that Sections 5 (Warranty
+Disclaimer) and 6 (Limitation of Liability) also govern Customer's use of the
+third-party software.  Customer agrees to comply with the terms and conditions
+of the relevant third-party software licenses.
+
+2. Support Services.  StrongLoop has no obligation to provide any support for
+the Software other than the support services specifically described on the
+StrongLoop Site for the Subscription level procured by Customer.  However,
+StrongLoop has endeavored to establish a community of users of the Software who
+have provided their own feedback, hints and advice regarding their experiences
+in using the Software.  You can find that community and user feedback on the
+StrongLoop Site.  The use of any information, content or other materials from,
+contained in or on the StrongLoop Site are subject to the StrongLoop website
+terms of use located here http://www.strongloop.com/terms-of-service.
+
+3. Confidentiality.  For purposes of this Agreement, "Confidential Information"
+means any and all information or proprietary materials (in every form and media)
+not generally known in the relevant trade or industry and which has been or is
+hereafter disclosed or made available by StrongLoop to Customer in connection
+with the transactions contemplated under this Agreement, including (i) all trade
+secrets, (ii) existing or contemplated Software, services, designs, technology,
+processes, technical data, engineering, techniques, methodologies and concepts
+and any related information, and (iii) information relating to business plans,
+sales or marketing methods and customer lists or requirements.  For a period of
+five (5) years from the date of disclosure of the applicable Confidential
+Information, Customer shall (i) hold the Confidential Information in trust and
+confidence and avoid the disclosure or release thereof to any other person or
+entity by using the same degree of care as it uses to avoid unauthorized use,
+disclosure, or dissemination of its own Confidential Information of a similar
+nature, but not less than reasonable care, and (ii) not use the Confidential
+Information for any purpose whatsoever except as expressly contemplated under
+this Agreement; provided that, to the extent the Confidential Information
+constitutes a trade secret under law, Customer agrees to protect such
+information for so long as it qualifies as a trade secret under applicable law.
+Customer shall disclose the Confidential Information only to those of its
+employees and contractors having a need to know such Confidential Information
+and shall take all reasonable precautions to ensure that such employees and
+contractors comply with the provisions of this Section.  The obligations of
+Customer under this Section shall not apply to information that Customer can
+demonstrate (i) was in its possession at the time of disclosure and without
+restriction as to confidentiality, (ii) at the time of disclosure is generally
+available to the public or after disclosure becomes generally available to the
+public through no breach of agreement or other wrongful act by Customer, (iii)
+has been received from a third party without restriction on disclosure and
+without breach of agreement by Customer, or (iv) is independently developed by
+Customer without regard to the Confidential Information.  In addition, Customer
+may disclose Confidential Information as required to comply with binding orders
+of governmental entities that have jurisdiction over it; provided that Customer
+gives StrongLoop reasonable written notice to allow StrongLoop to seek a
+protective order or other appropriate remedy, discloses only such Confidential
+Information as is required by the governmental entity, and uses commercially
+reasonable efforts to obtain confidential treatment for any Confidential
+Information disclosed.  Notwithstanding the above, Customer agrees that
+StrongLoop, its employees and agents shall be free to use and employ their
+general skills, know-how, and expertise, and to use, disclose, and employ any
+generalized ideas, concepts, know-how, methods, techniques or skills gained or
+learned during the Term or thereafter.
+
+4. Ownership.  StrongLoop shall retain all intellectual property and proprietary
+rights in the Software, Documentation, and related works, including but not
+limited to any derivative work of the foregoing and StrongLoop's licensors shall
+retain all intellectual property and proprietary rights in any Third-Party
+Software that may be provided with or as a part of the Software.  Customer shall
+do nothing inconsistent with StrongLoop's or its licensors' title to the
+Software and the intellectual property rights embodied therein, including, but
+not limited to, transferring, loaning, selling, assigning, pledging, or
+otherwise disposing, encumbering, or suffering a lien or encumbrance upon or
+against any interest in the Software.  The Software (including any Third-Party
+Software) contain copyrighted material, trade secrets and other proprietary
+material of StrongLoop and/or its licensors.
+
+5. Warranty Disclaimer.  THE SOFTWARE (INCLUDING ANY THIRD-PARTY SOFTWARE) AND
+DOCUMENTATION MADE AVAILABLE TO CUSTOMER ARE PROVIDED "AS-IS" AND STRONGLOOP,
+ON BEHALF OF ITSELF AND ITS LICENSORS, EXPRESSLY DISCLAIMS ALL WARRANTIES OF ANY
+KIND, EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, ANY IMPLIED WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, TITLE,
+PERFORMANCE, AND ACCURACY AND ANY IMPLIED WARRANTIES ARISING FROM STATUTE,
+COURSE OF DEALING, COURSE OF PERFORMANCE, OR USAGE OF TRADE.  STRONGLOOP DOES
+NOT WARRANT THAT THE OPERATION OF THE SOFTWARE WILL BE UNINTERRUPTED OR
+ERROR-FREE, THAT DEFECTS IN THE SOFTWARE WILL BE CORRECTED OR THAT THE SOFTWARE
+WILL PROVIDE OR ENSURE ANY PARTICULAR RESULTS OR OUTCOME.  NO ORAL OR WRITTEN
+INFORMATION OR ADVICE GIVEN BY STRONGLOOP OR ITS AUTHORIZED REPRESENTATIVES
+SHALL CREATE A WARRANTY OR IN ANY WAY INCREASE THE SCOPE OF THIS WARRANTY.
+STRONGLOOP IS NOT OBLIGATED TO PROVIDE CUSTOMER WITH UPGRADES TO THE SOFTWARE,
+BUT MAY ELECT TO DO SO IN ITS SOLE DISCRETION. SOME JURISDICTIONS DO NOT ALLOW
+THE EXCLUSION OF IMPLIED WARRANTIES, SO THE ABOVE EXCLUSION MAY NOT APPLY TO
+CUSTOMER.WITHOUT LIMITING THE GENERALITY OF THE FOREGOING DISCLAIMER, THE
+SOFTWARE AND DOCUMENTATION ARE NOT DESIGNED, MANUFACTURED OR INTENDED FOR USE IN
+THE PLANNING, CONSTRUCTION, MAINTENANCE, CONTROL, OR DIRECT OPERATION OF NUCLEAR
+FACILITIES, AIRCRAFT NAVIGATION, CONTROL OR COMMUNICATION SYSTEMS, WEAPONS
+SYSTEMS, OR DIRECT LIFE SUPPORT SYSTEMS.
+
+6. Limitation of Liability.
+
+6.1 Exclusion of Liability.  IN NO EVENT WILL STRONGLOOP OR ITS LICENSORS
+BE LIABLE UNDER THIS AGREEMENT FOR ANY INDIRECT, RELIANCE, PUNITIVE,
+CONSEQUENTIAL, SPECIAL, EXEMPLARY, OR INCIDENTAL DAMAGES OF ANY KIND AND
+HOWEVER CAUSED (INCLUDING, WITHOUT LIMITATION, DAMAGES FOR LOSS OF
+BUSINESS PROFITS, BUSINESS INTERRUPTION, LOSS OF BUSINESS INFORMATION AND
+THE LIKE), EVEN IF STRONGLOOP HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGES.  CUSTOMER BEARS FULL RESPONSIBILITY FOR USE OF THE SOFTWARE AND
+THE SUBSCRIPTION AND STRONGLOOP DOES NOT GUARANTEE THAT THE USE OF THE
+SOFTWARE AND SUBSCRIPTION WILL ENSURE THAT CUSTOMER'S NETWORK WILL BE
+AVAILABLE, SECURE, MONITORED OR PROTECTED AGAINST ANY DOWNTIME, DENIAL OF
+SERVICE ATTACKS, SECUITY BREACHES, HACKERS AND THE LIKE.  IN NO EVENT WILL
+STRONGLOOP'S CUMULATIVE LIABILITY FOR ANY DAMAGES, LOSSES AND CAUSES OF
+ACTION (WHETHER IN CONTRACT, TORT, INCLUDING NEGLIGENCE, OR OTHERWISE)
+ARISING OUT OF OR RELATED TO THIS AGREEMENT EXCEED THE GREATER OF ONE
+HUNDRED DOLLARS (US$100) OR THE TOTAL SUBSCRIPTION FEES PAID BY CUSTOMER
+TO STRONGLOOP IN THE TWELVE (12) MONTHS PRECEDING THE DATE THE CLAIM
+ARISES.
+
+6.2 Limitation of Damages.  IN NO EVENT WILL STRONGLOOP'S LICENSORS HAVE
+ANY LIABILITY FOR ANY CLAIM ARISING IN CONNECTION WITH THIS AGREEMENT.
+THE PROVISIONS OF THIS SECTION 6 ALLOCATE RISKS UNDER THIS AGREEMENT
+BETWEEN CUSTOMER, STRONGLOOP AND STRONGLOOP'S SUPPLIERS.  THE FOREGOING
+LIMITATIONS, EXCLUSIONS AND DISCLAIMERS APPLY TO THE MAXIMUM EXTENT
+PERMITTED BY APPLICABLE LAW, EVEN IF ANY REMEDY FAILS IN ITS ESSENTIAL
+PURPOSE.
+
+6.3 Failure of Essential Purpose.  THE PARTIES AGREE THAT THESE
+LIMITATIONS SHALL APPLY EVEN IF THIS AGREEMENT OR ANY LIMITED REMEDY
+SPECIFIED HEREIN IS FOUND TO HAVE FAILED OF ITS ESSENTIAL PURPOSE.
+
+6.4 Allocation of Risk.  The sections on limitation of liability and
+disclaimer of warranties allocate the risks in the Agreement between the
+parties.  This allocation is an essential element of the basis of the
+bargain between the parties.
+
+7. Term and Termination.
+
+7.1 This Agreement shall commence on the Effective Date and continue for so long
+as Customer has a valid Subscription and is current on the payment of any
+Subscription Fees required to be paid for that Subscription (the "Subscription
+Term").  Either party may terminate this Agreement immediately upon written
+notice to the other party, and the Subscription and licenses granted hereunder
+automatically terminate upon the termination of this Agreement.  This Agreement
+will terminate immediately without notice from StrongLoop if Customer fails to
+comply with or otherwise breaches any provision of this Agreement.
+
+7.2 All Sections other than Section 1.1 (Subscriptions) and 1.2 (Licenses) shall
+survive the expiration or termination of this Agreement.
+
+8. Subscription Fees and Payments.  StrongLoop, Customer agrees to pay
+StrongLoop the Subscription Fees as described on the StrongLoop Site for the
+Subscription purchased unless a different amount has been agreed to in a
+separate agreement between Customer and StrongLoop.  In addition, Customer shall
+pay all sales, use, value added, withholding, excise taxes and other tax, duty,
+custom and similar fees levied upon the delivery or use of the Software and the
+Subscriptions described in this Agreement.  Fees shall be invoiced in full upon
+StrongLoop's acceptance of Customer's purchase order for the Subscription.  All
+invoices shall be paid in US dollars and are due upon receipt and shall be paid
+within thirty (30) days. Payments shall be made without right of set-off or
+chargeback. If Customer does not pay the invoices when due, StrongLoop may
+charge interest at one percent (1%) per month or the highest rate permitted by
+law, whichever is lower, on the unpaid balance from the original due date. If
+Customer fails to pay fees in accordance with this Section, StrongLoop may
+suspend fulfilling its obligations under this Agreement (including but not
+limited to suspending the services under the Subscription) until payment is
+received by StrongLoop.  If any applicable law requires Customer to withhold
+amounts from any payments to StrongLoop under this Agreement, (a) Customer shall
+effect such withholding, remit such amounts to the appropriate taxing
+authorities and promptly furnish StrongLoop with tax receipts evidencing the
+payments of such amounts and (b) the sum payable by Customer upon which the
+deduction or withholding is based shall be increased to the extent necessary to
+ensure that, after such deduction or withholding, StrongLoop receives and
+retains, free from liability for such deduction or withholding, a net amount
+equal to the amount StrongLoop would have received and retained absent the
+required deduction or withholding.
+
+9. General.
+
+9.1 Compliance with Laws.  Customer shall abide by all local, state, federal and
+international laws, rules, regulations and orders applying to Customer's use of
+the Software, including, without limitation, the laws and regulations of the
+United States that may restrict the export and re-export of certain commodities
+and technical data of United States origin, including the Software.  Customer
+agrees that it will not export or re-export the Software without the appropriate
+United States or foreign government licenses.
+
+9.2 Entire Agreement.  This Agreement constitutes the entire agreement between
+the parties concerning the subject matter hereof.  This Agreement supersedes all
+prior or contemporaneous discussions, proposals and agreements between the
+parties relating to the subject matter hereof.  No amendment, modification or
+waiver of any provision of this Agreement shall be effective unless in writing
+and signed by both parties.  Any additional or different terms on any purchase
+orders issued by Customer to StrongLoop shall not be binding on either party,
+are hereby rejected by StrongLoop and void.
+
+9.3 Severability.  If any provision of this Agreement is held to be invalid or
+unenforceable, the remaining portions shall remain in full force and effect and
+such provision shall be enforced to the maximum extent possible so as to effect
+the intent of the parties and shall be reformed to the extent necessary to make
+such provision valid and enforceable.
+
+9.4 Waiver.  No waiver of rights by either party may be implied from any actions
+or failures to enforce rights under this Agreement.
+
+9.5 Force Majeure.  Neither party shall be liable to the other for any delay or
+failure to perform due to causes beyond its reasonable control (excluding
+payment of monies due).
+
+9.6 No Third Party Beneficiaries.  Unless otherwise specifically stated, the
+terms of this Agreement are intended to be and are solely for the benefit of
+StrongLoop and Customer and do not create any right in favor of any third party.
+
+9.7 Governing Law and Jurisdiction.  This Agreement shall be governed by the
+laws of the State of California, without reference to the principles of
+conflicts of law.  The provisions of the Uniform Computerized Information
+Transaction Act and United Nations Convention on Contracts for the International
+Sale of Goods shall not apply to this Agreement.  The parties shall attempt to
+resolve any dispute related to this Agreement informally, initially through
+their respective management, and then by non-binding mediation in San Francisco
+County, California.  Any litigation related to this Agreement shall be brought
+in the state or federal courts located in San Francisco County, California, and
+only in those courts and each party irrevocably waives any objections to such
+venue.
+
+9.8 Notices.  All notices must be in writing and shall be effective three (3)
+days after the date sent to the other party's headquarters, Attention Chief
+Financial Officer.

--- a/lib/license.js
+++ b/lib/license.js
@@ -1,0 +1,155 @@
+'use strict';
+
+var _ = require('lodash');
+var assert = require('assert');
+var debug = require('debug')('strong-tools:fix-license');
+var exec = require('child_process').execSync;
+var fs = require('fs');
+var json = require('json-file-plus');
+var path = require('path');
+
+var STRONGLOOP = fs.readFileSync(require.resolve('./STRONGLOOP.tpl'));
+var DUAL_MIT = fs.readFileSync(require.resolve('./DUAL_MIT.tpl'));
+var DUAL_ARTISTIC = fs.readFileSync(require.resolve('./DUAL_ARTISTIC.tpl'));
+
+assert(exec, 'node 0.12+ is required by the license utility');
+
+module.exports.cli = fixCli;
+
+/*
+TODO
+
+Add logic based on package name:
+
+- repos with the string 'example' in their package name are allowed to be
+  MIT-ONLY: the package.license property should be `MIT`, and there should
+  NOT be a LICENSE or LICENSE.md file
+
+- repos that do NOT contain strong or loopback in them should not have their
+  packages modified... the tool could skip them (or you can not run the tool
+  on non-strongloop repos!)
+*/
+
+function fixCli(pkgPath) {
+  pkgPath = pkgPath || 'package.json';
+  debug(pkgPath);
+  json(pkgPath, function(err, file) {
+    assert.ifError(err);
+
+    var name = file.data.name;
+    var license = file.data.license;
+
+    if (!license) {
+      console.error('%s: no license property!', name);
+      process.exit(1);
+    }
+
+    debug('license: %j', license);
+
+    // License object
+    switch (license.name) {
+      case 'StrongLoop': // OBSOLETE
+        file.data.license = 'SEE LICENSE IN LICENSE.md';
+        writeStrongloopLicense();
+        return save();
+
+      case 'Dual Artistic/StrongLoop': // OBSOLETE
+      case 'Dual Artistic-2.0/StrongLoop': // OBSOLETE
+        file.data.license = 'Artistic-2.0';
+        writeArtisticLicense(name);
+        return save();
+
+      case 'Dual MIT/StrongLoop': // OBSOLETE
+        file.data.license = 'MIT';
+        writeMitLicense(name);
+        return save();
+    }
+
+    // License string
+    switch (license) {
+      case '(Artistic-2.0 OR LicenseRef-LICENSE.md)': // OBSOLETE
+      case 'Artistic-2.0 OR LicenseRef-LICENSE.md': // OBSOLETE
+      case 'Artistic-2.0 OR LicenseRef-LICENSE': // OBSOLETE
+      case 'Artistic 2.0': // OBSOLETE
+        file.data.license = 'Artistic-2.0';
+        writeArtisticLicense(name);
+        return save();
+
+      case 'LicenseRef-LICENSE.md': // OBSOLETE
+      case 'LicenseRef-LICENSE': // OBSOLETE
+      case 'SEE LICENSE IN LICENSE': // OBSOLETE
+        file.data.license = 'SEE LICENSE IN LICENSE.md';
+        writeStrongloopLicense();
+        return save();
+
+
+        // The only current VALID license forms:
+
+      case 'SEE LICENSE IN LICENSE.md': // STRONGLOOP ONLY
+        writeStrongloopLicense();
+        return ok();
+
+      case 'Artistic-2.0': // ARTISTIC-2.0 or STRONGLOOP
+        writeArtisticLicense(name);
+        return ok();
+
+      case 'MIT': // MIT or STRONGLOOP
+        writeMitLicense(name);
+        return ok();
+
+      default:
+        console.log('wrong %s: license unknown %j', name, license);
+        process.exit(1);
+    }
+
+    function ok() {
+      console.log('valid %s: %j', name, license);
+      process.exit(0);
+    }
+
+    function save() {
+      console.log('fixed %s: %j to %j', name, license, file.data.license);
+
+      file.save(function(err) {
+        assert.ifError(err);
+        process.exit(0);
+      });
+    }
+  });
+}
+
+function writeStrongloopLicense() {
+  fs.writeFileSync('LICENSE.md', STRONGLOOP);
+  exec('git add LICENSE.md');
+  try {
+    fs.statSync('LICENSE');
+    exec('git rm -f LICENSE');
+  } catch(_) {
+  }
+}
+
+// Note - Loopback dual sl/mit license is different from the Nodeops dual
+// sl/artistic license, it has a different name, and it has copies of license
+// text as opposed to markdown references.
+function writeMitLicense(pkgName) {
+  writeTemplatedLicense('LICENSE', 'LICENSE.md', DUAL_MIT, pkgName);
+}
+
+function writeArtisticLicense(pkgName) {
+  writeTemplatedLicense('LICENSE.md', 'LICENSE', DUAL_ARTISTIC, pkgName);
+}
+
+function writeTemplatedLicense(newName, oldName, text, pkgName) {
+  assert(newName);
+  assert(oldName);
+  assert(text);
+  assert(pkgName);
+  var license = _.template(String(text))({name: pkgName});
+  fs.writeFileSync(newName, license);
+  exec('git add ' + newName);
+  try {
+    fs.statSync(oldName);
+    exec('git rm -f ' + oldName);
+  } catch(_) {
+  }
+}

--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
   },
   "homepage": "https://github.com/strongloop/strong-tools",
   "dependencies": {
+    "debug": "^2.2.0",
     "gift": "^0.6.1",
+    "json-file-plus": "^3.0.1",
     "lodash": "^3.10.1",
     "normalize-license-data": "^1.0.1",
     "normalize-package-data": "^2.3.2",


### PR DESCRIPTION
It detects obsolete license specifications used by StrongLoop, and
converts them to a currently valid specification.

It also rewrites the LICENSE or LICENSE.md file for a valid license
specification, guaranteeing consistent text for all license files.

The existence of the tool should help keep current packages consistent,
as well as allowing any future changes we decide to make to the
licensing (such as adjustments to the format of the license files) much
easier, perhaps trivial.

connected to strongloop-internal/scrum-nodeops#871