### PR TITLE
Rewrite slt-changelog in JavaScript

### DIFF
--- a/bin/slt-changelog.js
+++ b/bin/slt-changelog.js
@@ -88,7 +88,7 @@ function gitChangelog(nextVersion) {
     var sha1b = gitSha1(b);
     var cmd = Promise.resolve(base + ' "%s..%s"');
     var entries = Promise.join(cmd, sha1a, sha1b, git)
-      .then(changelogFilter(b)) // should be cleanVersion(b)
+      .then(changelogFilter(cleanVersion(b)))
       .then(function(lines) {
         return lines.join('\n');
       });
@@ -178,7 +178,7 @@ function changelogFilter(tagName) {
   function filter(log) {
     return _(log)
       .reject(function(line) {
-        return _.startsWith(line, tagName);
+        return _.startsWith(line, tagName + ' (');
       })
       .reject(matching(/^Merge/))
       .reject(matching(/^v?\d+\.\d+\.\d+ \(/))

--- a/bin/slt-changelog.js
+++ b/bin/slt-changelog.js
@@ -1,0 +1,204 @@
+#!/usr/bin/env node
+'use strict';
+
+var Promise = require('bluebird');
+var _ = require('lodash');
+var cp = require('child_process');
+var fmt = require('util').format;
+var minimist = require('minimist');
+var writeFile = Promise.promisify(require('fs').writeFile);
+
+var ARGS = process.argv.slice(2);
+var OPTS = {alias: {v: 'version', s: 'summary'}};
+var strip = _.method('trim');
+var TODAY = (new Date()).toISOString().split('T')[0];
+
+return Promise.resolve(minimist(ARGS, OPTS)).then(function(opts) {
+  if (opts.summary) {
+    return gitLatest(opts.version).then(console.log);
+  }
+  return gitChangelog(opts.version).then(function(log) {
+    return writeFile(opts._[0] || 'CHANGES.md', log);
+  });
+}).catch(function(err) {
+  console.error('Error fulfilling request:', err);
+});
+
+function gitLatest(version) {
+  // --full-history: include individual commits from merged branches
+  // --date-order: order commits by date, not topological order
+  var logCmd = 'log --full-history --date-order --pretty="format:%%s (%%an)"';
+  var tagsByTopo = gitTagsByTopo();
+  var lastRelease = tagsByTopo.then(function(tags) {
+    return gitSha1(_.last(tags));
+  });
+  return Promise.join(lastRelease, gitSha1('HEAD'), function(last, head) {
+    if (!last) {
+      return [' * First release!'];
+    } else if (head !== last) {
+      return git(logCmd + ' %s..', last)
+        .then(changelogFilter())
+        .then(function(lines) {
+          return [lines.join('')];
+        });
+    } else {
+      return [];
+    }
+  }).then(function(release) {
+    if (version) {
+      release.push(cleanVersion(version) + '\n\n');
+    }
+    return release.reverse().join('');
+  });
+}
+
+function gitChangelog(nextVersion) {
+  var base = 'log --full-history --date-order --pretty="format:%%s (%%an)"';
+  return gitTagsByTopo().then(function(tags) {
+    var releases = [firstRelease(tags)];
+    for (var i = 1; i < tags.length; i++) {
+      releases.push(midRelease(tags[i - 1], tags[i]));
+    }
+    if (nextVersion && tags.length > 0) {
+      releases.push(nextRelease(tags));
+    }
+    return releases;
+  }).then(Promise.all).then(function(releases) {
+    return releases.reverse().join('\n\n');
+  });
+
+  // First release doesn't have a full changelog
+  function firstRelease(tags) {
+    var entries = Promise.resolve(' * First release!\n');
+    var t, v;
+    if (_.isEmpty(tags)) {
+      t = Promise.resolve(TODAY);
+      v = Promise.resolve(cleanVersion(nextRelease || '0.0.0'));
+    } else {
+      t = gitDateOf(_.first(tags));
+      v = Promise.resolve(cleanVersion(_.first(tags)));
+    }
+    return Promise.join(t, v, entries, formatRelease);
+  }
+
+  function midRelease(a, b) {
+    var t = gitDateOf(b);
+    var v = Promise.resolve(cleanVersion(b));
+    var sha1a = gitSha1(a);
+    var sha1b = gitSha1(b);
+    var cmd = Promise.resolve(base + ' "%s..%s"');
+    var entries = Promise.join(cmd, sha1a, sha1b, git)
+      .then(changelogFilter(b)) // should be cleanVersion(b)
+      .then(function(lines) {
+        return lines.join('\n');
+      });
+    return Promise.join(t, v, entries, formatRelease);
+  }
+
+  function nextRelease(tags) {
+    var head = gitSha1('HEAD');
+    var last = gitSha1(_.last(tags));
+    return Promise.join(head, last, function(head, last) {
+      if (head === last) {
+        return;
+      }
+      var t = Promise.resolve(TODAY);
+      var v = Promise.resolve(cleanVersion(nextVersion));
+      var entries = git(base + ' %s..', last)
+        .then(changelogFilter(cleanVersion(nextVersion)))
+        .then(function(lines) {
+          return lines.join('\n');
+        });
+      return Promise.join(t, v, entries, formatRelease);
+    });
+  }
+
+  function formatRelease(t, v, entries) {
+    var heading = fmt('%s, Version %s', t, v);
+    var underline = _.repeat('=', heading.length);
+    return fmt('%s\n%s\n\n%s', heading, underline, entries);
+  }
+}
+
+function gitSha1(ref) {
+  return git('rev-list -n 1 %s', ref)
+    .then(_.first)
+    .then(strip);
+}
+
+function gitDateOf(ref) {
+  return gitSha1(ref)
+    .then(function(sha1) {
+      return git('log --date=iso --format="%%ad" -n1 "%s"', sha1);
+    })
+    .then(_.first)
+    .then(function(str) {
+      return str.split(' ')[0];
+    });
+}
+
+function gitTagsByTopo() {
+  var allTags = git('tag');
+  var tagRevs = Promise.map(allTags, gitSha1);
+  var branchRevs = git('rev-list --simplify-by-decoration --topo-order HEAD');
+  return Promise.join(allTags, tagRevs, branchRevs, function(tags, revs, brs) {
+    tags = _.zip(tags, revs);
+    brs = brs.reverse();
+    return _(tags).select(function(t) {
+      return _.includes(brs, t[1]);
+    }).sortBy(function(t) {
+      return brs.indexOf(t[1]);
+    })
+    .pluck(0)
+    .value();
+  });
+}
+
+function git(cmdAndArgs) {
+  var cmd = 'git ' + fmt.apply(null, arguments);
+  git.cache = git.cache || Object.create(null);
+  if (cmd in git.cache) {
+    return Promise.resolve(git.cache[cmd]);
+  }
+  return new Promise(function(resolve, reject) {
+    cp.exec(cmd, function(err, stdout, stderr) {
+      stdout = _(stdout || '').split(/[\r\n]+/g).map(_.trim).select().value();
+      if (err) {
+        reject(err);
+      } else {
+        git.cache[cmd] = stdout;
+        resolve(stdout);
+      }
+    });
+  });
+}
+
+function changelogFilter(tagName) {
+  return filter;
+  function filter(log) {
+    return _(log)
+      .reject(function(line) {
+        return _.startsWith(line, tagName);
+      })
+      .reject(matching(/^Merge/))
+      .reject(matching(/^v?\d+\.\d+\.\d+ \(/))
+      .reject(matching(/update changes.md/i))
+      .reject(matching(/update changelog/i))
+      .uniq()
+      .map(function(line) {
+        return ' * ' + line + '\n';
+      })
+      .value();
+  }
+}
+
+function matching(re) {
+  return match;
+  function match(str) {
+    return re.test(str);
+  }
+}
+
+function cleanVersion(tag) {
+  return tag.replace(/^v/, '');
+}

--- a/bin/slt-changelog.rb
+++ b/bin/slt-changelog.rb
@@ -38,7 +38,7 @@ class GitRepo
     tags.each_cons(2) do |a,b|
       release_heading = "#{date_of(b)}, Version #{clean_version(b)}"
       release = []
-      release << changelog_filter(`#{base} "#{sha1(a)}..#{sha1(b)}"`).join("\n")
+      release << changelog_filter(clean_version(b), `#{base} "#{sha1(a)}..#{sha1(b)}"`).join("\n")
       next if release.empty?
       release << "#{release_heading}\n#{'='*release_heading.length}\n"
       releases << release.reverse.join("\n")
@@ -48,7 +48,7 @@ class GitRepo
     if next_release and tags.length > 0 and sha1('HEAD') != sha1(tags.last)
       release_heading = "#{Time.now.utc.strftime("%Y-%m-%d")}, Version #{clean_version(next_release)}"
       release = []
-      release << changelog_filter(`#{base} #{sha1(tags.last)}..`).join("\n")
+      release << changelog_filter(clean_version(next_release), `#{base} #{sha1(tags.last)}..`).join("\n")
       release << "#{release_heading}\n#{'='*release_heading.length}\n" unless release.empty?
       releases << release.reverse.join("\n") unless release.empty?
     end
@@ -79,7 +79,7 @@ class GitRepo
     if last_release.nil?
       release << ' * First release!'
     elsif sha1('HEAD') != sha1(last_release)
-      release << changelog_filter(`#{base} #{last_release}..`).join
+      release << changelog_filter(version, `#{base} #{last_release}..`).join
     end
     if version
       release << "#{clean_version(version)}\n\n"
@@ -87,9 +87,10 @@ class GitRepo
     release.reverse.join
   end
 
-  def changelog_filter(log)
+  def changelog_filter(v, log)
     log.lines
        .map(&:strip)
+       .reject { |line| line.start_with?(v + ' (') }
        .reject { |line| line =~ /^Merge/ }
        .reject { |line| line =~ /^v?\d+\.\d+\.\d+ \(/ }
        .reject { |line| line =~ /update changes.md/i }

--- a/bin/slt-changelog.rb
+++ b/bin/slt-changelog.rb
@@ -11,7 +11,8 @@ class GitRepo
       cache[ref] = `#{git} rev-list -n 1 #{ref}`.strip
     end
     @date_of = Hash.new do |cache, ref|
-      cache[ref] = DateTime.parse(`#{git} log --date=iso --format="%ad" -n1 "#{ref}"`.strip) #.utc
+      d = `#{git} log --date=iso --format="%ad" -n1 "#{ref}"`.strip
+      cache[ref] = d.split(' ')[0]
     end
   end
 
@@ -26,7 +27,7 @@ class GitRepo
     if tags.empty?
       release_heading = "#{Time.now.utc.strftime("%Y-%m-%d")}, Version #{clean_version(next_release || '0.0.0')}"
     else
-      release_heading = "#{date_of(tags.first).strftime("%Y-%m-%d")}, Version #{clean_version(tags.first)}"
+      release_heading = "#{date_of(tags.first)}, Version #{clean_version(tags.first)}"
     end
     release = []
     release << " * First release!"
@@ -35,7 +36,7 @@ class GitRepo
 
     # 2nd, 3rd, etc. releases have changes between them
     tags.each_cons(2) do |a,b|
-      release_heading = "#{date_of(b).strftime("%Y-%m-%d")}, Version #{clean_version(b)}"
+      release_heading = "#{date_of(b)}, Version #{clean_version(b)}"
       release = []
       release << changelog_filter(`#{base} "#{sha1(a)}..#{sha1(b)}"`).join("\n")
       next if release.empty?

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "slt": "bin/slt.js",
     "slt-release": "bin/slt-release.sh",
     "slt-stage": "bin/slt-stage.rb",
-    "slt-changelog": "bin/slt-changelog.rb"
+    "slt-changelog": "bin/slt-changelog.js"
   },
   "devDependencies": {
     "eslint": "^1.10.0",


### PR DESCRIPTION
Node: 204 lines
Ruby: 149 lines

It's not as much longer as I feared it might be. I think a lot of that is owed to how well Promises mix with my style of functional programming.

Note that these produce identical output in the "bug compatible" sense, and the commit that fixes the version commit filtering fixes that bug in both versions of the command.