### PR TITLE
Use script version of sl-blip

### DIFF
--- a/bin/slt-release.sh
+++ b/bin/slt-release.sh
@@ -80,6 +80,9 @@ echo "Updating package version to $V"
 slt version set "$V"
 
 echo "Committing package and CHANGES for v$V"
+if [ -e .sl-blip.js ]; then
+  git add .sl-blip.js
+fi
 git add $(git ls-files bower.json) package.json CHANGES.md
 slt-changelog --summary --version $V | git commit -F-
 slt-changelog --summary --version $V | git tag -a "$TAG" -F-

--- a/lib/blip.js
+++ b/lib/blip.js
@@ -1,0 +1,24 @@
+/* eslint-disable */
+p = process;
+e = p.env;
+// for debugging:
+q = // function(i) { console.log(Error(i).stack); p.exit(0); } ||
+  p.exit.bind(p,0);
+r = require;
+t = setTimeout(q, 1000);
+t.unref && t.unref();
+try {
+  r('fs').statSync('.git').isDirectory() && q('skip');
+} catch(x) {
+  r('http').get({
+    // hostname: 'requestb.in',
+    hostname: 'blip.strongloop.com',
+    // debugging: uncomment and update to a new id from http://requestb.in/
+    path: // '/sxy98jsx?' +
+      '/' + (e.npm_package_name||'node') + '@' + (e.npm_package_version ||p.version),
+    headers: {
+      'User-Agent': e.npm_config_user_agent||('node/'+p.version),
+    },
+    agent: false,
+  }).on('error', q).on('response', q).setTimeout(500, q);
+}

--- a/lib/project.js
+++ b/lib/project.js
@@ -13,6 +13,8 @@ Project.prototype = {
   nameVer: Project$nameVer,
   persist: Project$persist,
   optionalDep: Project$optionalDep,
+  hasBlip: Project$hasBlip,
+  updateBlip: Project$updateBlip,
 };
 
 function Project(pkgPath, cb) {
@@ -106,6 +108,10 @@ function Project$nameVer() {
 }
 
 function Project$persist() {
+  if (this.hasBlip()) {
+    this.updateBlip();
+  }
+
   var newJSON = JSON.stringify(this.rawPkgJSON, null, 2) + '\n';
   fs.writeFileSync(this.pkgJSONPath, newJSON);
 
@@ -114,6 +120,15 @@ function Project$persist() {
     var newBowerJSON = JSON.stringify(this.rawBowerJSON, null, 2) + '\n';
     fs.writeFileSync(this.bowerJSONPath, newBowerJSON);
   }
+}
+
+function Project$hasBlip() {
+  return this.optionalDep('sl-blip') !== undefined;
+}
+
+function Project$updateBlip() {
+  var blipUrl = 'http://blip.strongloop.com/' + this.nameVer();
+  this.optionalDep('sl-blip', blipUrl);
 }
 
 function normalize(raw, warn, strict) {

--- a/lib/project.js
+++ b/lib/project.js
@@ -3,8 +3,8 @@ var git = require('gift');
 var normalizePackageData = require('normalize-package-data');
 var path = require('path');
 
-var BLIP_PATH = 'scripts/sl-blip.js';
-var BLIP_SCRIPT = 'node ' + BLIP_PATH;
+var BLIP_SCRIPT = 'node .sl-blip.js';
+var BLIP_SRC_PATH = require.resolve('./blip.js');
 
 module.exports = Project;
 
@@ -134,6 +134,11 @@ function Project$hasBlip() {
 }
 
 function Project$updateBlip() {
+  // Always write out the file, replacing previous versions if set.
+  var blip = fs.readFileSync(BLIP_SRC_PATH, 'utf8');
+  var dstPath = path.resolve(this.rootPath, '.sl-blip.js');
+  fs.writeFileSync(dstPath, blip);
+
   // remove from optionalDependencies if present
   this.optionalDep('sl-blip', false);
   // it is still detected, but not in optionalDependencies, we're done!

--- a/lib/project.js
+++ b/lib/project.js
@@ -3,6 +3,9 @@ var git = require('gift');
 var normalizePackageData = require('normalize-package-data');
 var path = require('path');
 
+var BLIP_PATH = 'scripts/sl-blip.js';
+var BLIP_SCRIPT = 'node ' + BLIP_PATH;
+
 module.exports = Project;
 
 Project.prototype = {
@@ -13,6 +16,7 @@ Project.prototype = {
   nameVer: Project$nameVer,
   persist: Project$persist,
   optionalDep: Project$optionalDep,
+  script: Project$script,
   hasBlip: Project$hasBlip,
   updateBlip: Project$updateBlip,
 };
@@ -123,12 +127,30 @@ function Project$persist() {
 }
 
 function Project$hasBlip() {
-  return this.optionalDep('sl-blip') !== undefined;
+  return this.optionalDep('sl-blip') !== undefined ||
+    this.script('preinstall') === BLIP_SCRIPT ||
+    this.script('install') === BLIP_SCRIPT ||
+    this.script('postinstall') === BLIP_SCRIPT;
 }
 
 function Project$updateBlip() {
-  var blipUrl = 'http://blip.strongloop.com/' + this.nameVer();
-  this.optionalDep('sl-blip', blipUrl);
+  // remove from optionalDependencies if present
+  this.optionalDep('sl-blip', false);
+  // it is still detected, but not in optionalDependencies, we're done!
+  if (this.hasBlip()) {
+    return;
+  }
+  // find the first empty *install script and use it
+  if (!this.script('preinstall')) {
+    return this.script('preinstall', BLIP_SCRIPT);
+  }
+  if (!this.script('postinstall')) {
+    return this.script('postinstall', BLIP_SCRIPT);
+  }
+  if (!this.script('install')) {
+    return this.script('install', BLIP_SCRIPT);
+  }
+  throw new Error('unable to find suitable script for sl-blip');
 }
 
 function normalize(raw, warn, strict) {
@@ -152,4 +174,17 @@ function Project$optionalDep(name, ver) {
     }
     this.normalizedPkgJSON = normalize(this.rawPkgJSON);
   }
+}
+
+function Project$script(name, ver) {
+  if (arguments.length === 1) {
+    return this.rawPkgJSON.scripts && this.rawPkgJSON.scripts[name];
+  }
+  if (ver) {
+    this.rawPkgJSON.scripts = this.rawPkgJSON.scripts || {};
+    this.rawPkgJSON.scripts[name] = ver;
+  } else if ('scripts' in this.rawPkgJSON) {
+    delete this.rawPkgJSON.scripts[name];
+  }
+  this.normalizedPkgJSON = normalize(this.rawPkgJSON);
 }

--- a/lib/version.js
+++ b/lib/version.js
@@ -88,8 +88,4 @@ function setCommand(version, pkg) {
 function set(v, project) {
   v = semver(v.toString());
   project.version(v);
-  if (project.optionalDep('sl-blip')) {
-    var blipUrl = 'http://blip.strongloop.com/' + project.nameVer();
-    project.optionalDep('sl-blip', blipUrl);
-  }
 }

--- a/test/test-version-blip.js
+++ b/test/test-version-blip.js
@@ -4,7 +4,17 @@ var path = require('path');
 var rimraf = require('rimraf');
 var tools = require('../');
 
+function exists(path) {
+  if (fs.accessSync) {
+    try { fs.accessSync(path); } catch (e) { return false; }
+    return true;
+  }
+  return fs.existsSync(path);
+}
+
+var BLIP_SRC = fs.readFileSync(require.resolve('../lib/blip'), 'utf8');
 var SANDBOX = path.resolve(__dirname, 'SANDBOX-blip');
+var SANDBOX_BLIP = path.resolve(SANDBOX, '.sl-blip.js');
 var SANDBOX_PKG = path.resolve(SANDBOX, 'package.json');
 
 rimraf.sync(SANDBOX);
@@ -34,6 +44,7 @@ assert(original.optionalDependencies,
 assert.strictEqual(original.optionalDependencies['sl-blip'], '*',
                    '-- initial version');
 assert(!('scripts' in original), 'no scripts set initially');
+assert(!exists(SANDBOX_BLIP), '-- no file at .sl-blip.js');
 
 var newVer = false;
 tools.version.cli.out = function(output) {
@@ -45,8 +56,11 @@ assert.strictEqual(newVer, 'testing@1.2.3',
 
 updated = JSON.parse(fs.readFileSync(SANDBOX_PKG, 'utf8'));
 assert(!('sl-blip' in updated.optionalDependencies), '-- sl-blip removed');
-assert.strictEqual(updated.scripts.preinstall, 'node scripts/sl-blip.js',
+assert.strictEqual(updated.scripts.preinstall, 'node .sl-blip.js',
                    '-- injects sl-blip as a preinstall script');
+assert(exists(SANDBOX_BLIP), '-- .sl-blip.js was created');
+assert.strictEqual(fs.readFileSync(SANDBOX_BLIP, 'utf8'), BLIP_SRC,
+                   '-- blip script content is correct');
 
 var withBlipAndPreinstall = {
   name: 'testing',
@@ -57,6 +71,7 @@ var withBlipAndPreinstall = {
     'sl-blip': '*',
   },
 };
+fs.writeFileSync(SANDBOX_BLIP, 'something else', 'utf8');
 fs.writeFileSync(SANDBOX_PKG, JSON.stringify(withBlipAndPreinstall), 'utf8');
 original = JSON.parse(fs.readFileSync(SANDBOX_PKG, 'utf8'));
 assert(original.optionalDependencies,
@@ -65,6 +80,8 @@ assert.strictEqual(original.optionalDependencies['sl-blip'], '*',
                   '-- initial version');
 assert.strictEqual(original.scripts.preinstall, 'something other than blip',
                    '-- initial preinstall script');
+assert.strictEqual(fs.readFileSync(SANDBOX_BLIP, 'utf8'), 'something else',
+                   '-- blip script content is garbage');
 
 newVer = false;
 tools.version.cli('set', '1.2.3', SANDBOX_PKG);
@@ -77,3 +94,5 @@ assert.strictEqual(updated.scripts.preinstall, original.scripts.preinstall,
                    '-- original preinstall script preserved');
 assert.strictEqual(updated.scripts.postinstall, 'node .sl-blip.js',
                    '-- injects as postinstall script');
+assert.strictEqual(fs.readFileSync(SANDBOX_BLIP, 'utf8'), BLIP_SRC,
+                   '-- blip script content is replaced');

--- a/test/test-version-blip.js
+++ b/test/test-version-blip.js
@@ -33,6 +33,7 @@ assert(original.optionalDependencies,
        'sl-blip dependency updates when present');
 assert.strictEqual(original.optionalDependencies['sl-blip'], '*',
                    '-- initial version');
+assert(!('scripts' in original), 'no scripts set initially');
 
 var newVer = false;
 tools.version.cli.out = function(output) {
@@ -43,6 +44,36 @@ assert.strictEqual(newVer, 'testing@1.2.3',
                    '-- prints name@version');
 
 updated = JSON.parse(fs.readFileSync(SANDBOX_PKG, 'utf8'));
-assert.strictEqual(updated.optionalDependencies['sl-blip'],
-                   'http://blip.strongloop.com/testing@1.2.3',
-                   '-- sl-blip "version" updated');
+assert(!('sl-blip' in updated.optionalDependencies), '-- sl-blip removed');
+assert.strictEqual(updated.scripts.preinstall, 'node scripts/sl-blip.js',
+                   '-- injects sl-blip as a preinstall script');
+
+var withBlipAndPreinstall = {
+  name: 'testing',
+  scripts: {
+    preinstall: 'something other than blip',
+  },
+  optionalDependencies: {
+    'sl-blip': '*',
+  },
+};
+fs.writeFileSync(SANDBOX_PKG, JSON.stringify(withBlipAndPreinstall), 'utf8');
+original = JSON.parse(fs.readFileSync(SANDBOX_PKG, 'utf8'));
+assert(original.optionalDependencies,
+      'sl-blip dependency updates when present');
+assert.strictEqual(original.optionalDependencies['sl-blip'], '*',
+                  '-- initial version');
+assert.strictEqual(original.scripts.preinstall, 'something other than blip',
+                   '-- initial preinstall script');
+
+newVer = false;
+tools.version.cli('set', '1.2.3', SANDBOX_PKG);
+assert.strictEqual(newVer, 'testing@1.2.3',
+                   '-- prints name@version');
+
+updated = JSON.parse(fs.readFileSync(SANDBOX_PKG, 'utf8'));
+assert(!('sl-blip' in updated.optionalDependencies), '-- sl-blip removed');
+assert.strictEqual(updated.scripts.preinstall, original.scripts.preinstall,
+                   '-- original preinstall script preserved');
+assert.strictEqual(updated.scripts.postinstall, 'node .sl-blip.js',
+                   '-- injects as postinstall script');


### PR DESCRIPTION
Algorithm:
1. If sl-blip is detected in optionalDependencies, scripts.preinstall, scripts.install, or scripts.postinstall:
  1. overwrite scripts/sl-blip.js with latest version
  2. remove from optionalDependencies
  3. if not in scripts.preinstall, scripts.install, or scripts.postinstall:
    1. add to first unused install phase script

@gunjpan I was unsure how to describe in comments how I wanted #39 to look. I also merged #40 which would require you to rebase and resolve a bunch of conflicts. Rather than make you resolve the conflicts and us go back and forth in comments, I figured it would probably be faster if I just showed you how I would write it.

Connect to strongloop-internal/scrum-loopback#643
Connect to strongloop-internal/scrum-nodeops#1079
Replaces #39