### PR TITLE
blip: use https instead of http

### DIFF
--- a/lib/blip.js
+++ b/lib/blip.js
@@ -10,7 +10,8 @@ t.unref && t.unref();
 try {
   r('fs').statSync('.git').isDirectory() && q('skip');
 } catch(x) {
-  r('http').get({
+  // debugging may require using http instead of https
+  r('https').get({
     // hostname: 'requestb.in',
     hostname: 'blip.strongloop.com',
     // debugging: uncomment and update to a new id from http://requestb.in/


### PR DESCRIPTION
There's no reason to use http here, honestly.

See https://github.com/strongloop/loopback/issues/1079#issuecomment-172551927

/cc @STRML