### PR TITLE
change blip script to not depend on node

### DIFF
--- a/lib/project.js
+++ b/lib/project.js
@@ -3,7 +3,8 @@ var git = require('gift');
 var normalizePackageData = require('normalize-package-data');
 var path = require('path');
 
-var BLIP_SCRIPT = 'node .sl-blip.js';
+var BLIP_SCRIPT = 'node .sl-blip.js || exit 0';
+var BLIP_SCRIPT_RX = /node \.sl-blip\.js/;
 var BLIP_SRC_PATH = require.resolve('./blip.js');
 
 module.exports = Project;
@@ -127,10 +128,10 @@ function Project$persist() {
 }
 
 function Project$hasBlip() {
-  return this.optionalDep('sl-blip') !== undefined ||
-    this.script('preinstall') === BLIP_SCRIPT ||
-    this.script('install') === BLIP_SCRIPT ||
-    this.script('postinstall') === BLIP_SCRIPT;
+  return this.optionalDep('sl-blip') ||
+    BLIP_SCRIPT_RX.test(this.script('preinstall')) ||
+    BLIP_SCRIPT_RX.test(this.script('install')) ||
+    BLIP_SCRIPT_RX.test(this.script('postinstall'));
 }
 
 function Project$updateBlip() {
@@ -141,10 +142,21 @@ function Project$updateBlip() {
 
   // remove from optionalDependencies if present
   this.optionalDep('sl-blip', false);
-  // it is still detected, but not in optionalDependencies, we're done!
+
+  // it is still detected, but not in optionalDependencies, make sure it is
+  // using the latest form.
   if (this.hasBlip()) {
-    return;
+    if (BLIP_SCRIPT_RX.test(this.script('preinstall'))) {
+      return this.script('preinstall', BLIP_SCRIPT);
+    }
+    if (BLIP_SCRIPT_RX.test(this.script('postinstall'))) {
+      return this.script('postinstall', BLIP_SCRIPT);
+    }
+    if (BLIP_SCRIPT_RX.test(this.script('install'))) {
+      return this.script('install', BLIP_SCRIPT);
+    }
   }
+
   // find the first empty *install script and use it
   if (!this.script('preinstall')) {
     return this.script('preinstall', BLIP_SCRIPT);

--- a/test/test-version-blip.js
+++ b/test/test-version-blip.js
@@ -17,6 +17,11 @@ var SANDBOX = path.resolve(__dirname, 'SANDBOX-blip');
 var SANDBOX_BLIP = path.resolve(SANDBOX, '.sl-blip.js');
 var SANDBOX_PKG = path.resolve(SANDBOX, 'package.json');
 
+var newVer = false;
+tools.version.cli.out = function(output) {
+  newVer = output;
+};
+
 rimraf.sync(SANDBOX);
 fs.mkdirSync(SANDBOX);
 fs.writeFileSync(SANDBOX_PKG, JSON.stringify({name: 'testing'}), 'utf8');
@@ -46,17 +51,14 @@ assert.strictEqual(original.optionalDependencies['sl-blip'], '*',
 assert(!('scripts' in original), 'no scripts set initially');
 assert(!exists(SANDBOX_BLIP), '-- no file at .sl-blip.js');
 
-var newVer = false;
-tools.version.cli.out = function(output) {
-  newVer = output;
-};
+newVer = false;
 tools.version.cli('set', '1.2.3', SANDBOX_PKG);
 assert.strictEqual(newVer, 'testing@1.2.3',
                    '-- prints name@version');
 
 updated = JSON.parse(fs.readFileSync(SANDBOX_PKG, 'utf8'));
 assert(!('sl-blip' in updated.optionalDependencies), '-- sl-blip removed');
-assert.strictEqual(updated.scripts.preinstall, 'node .sl-blip.js',
+assert.strictEqual(updated.scripts.preinstall, 'node .sl-blip.js || exit 0',
                    '-- injects sl-blip as a preinstall script');
 assert(exists(SANDBOX_BLIP), '-- .sl-blip.js was created');
 assert.strictEqual(fs.readFileSync(SANDBOX_BLIP, 'utf8'), BLIP_SRC,
@@ -82,7 +84,6 @@ assert.strictEqual(original.scripts.preinstall, 'something other than blip',
                    '-- initial preinstall script');
 assert.strictEqual(fs.readFileSync(SANDBOX_BLIP, 'utf8'), 'something else',
                    '-- blip script content is garbage');
-
 newVer = false;
 tools.version.cli('set', '1.2.3', SANDBOX_PKG);
 assert.strictEqual(newVer, 'testing@1.2.3',
@@ -92,7 +93,33 @@ updated = JSON.parse(fs.readFileSync(SANDBOX_PKG, 'utf8'));
 assert(!('sl-blip' in updated.optionalDependencies), '-- sl-blip removed');
 assert.strictEqual(updated.scripts.preinstall, original.scripts.preinstall,
                    '-- original preinstall script preserved');
-assert.strictEqual(updated.scripts.postinstall, 'node .sl-blip.js',
+assert.strictEqual(updated.scripts.postinstall, 'node .sl-blip.js || exit 0',
                    '-- injects as postinstall script');
+assert.strictEqual(fs.readFileSync(SANDBOX_BLIP, 'utf8'), BLIP_SRC,
+                   '-- blip script content is replaced');
+
+var withOldBlipInstall = {
+  name: 'testing',
+  scripts: {
+    install: 'node .sl-blip.js',
+  },
+};
+fs.writeFileSync(SANDBOX_BLIP, 'something else', 'utf8');
+fs.writeFileSync(SANDBOX_PKG, JSON.stringify(withOldBlipInstall), 'utf8');
+original = JSON.parse(fs.readFileSync(SANDBOX_PKG, 'utf8'));
+assert(original.name,
+      'sl-blip script in old form updates when present');
+assert.strictEqual(original.scripts.install, 'node .sl-blip.js',
+                   '-- initial install script');
+assert.strictEqual(fs.readFileSync(SANDBOX_BLIP, 'utf8'), 'something else',
+                   '-- blip script content is garbage');
+newVer = false;
+tools.version.cli('set', '1.1.2', SANDBOX_PKG);
+assert.strictEqual(newVer, 'testing@1.1.2',
+                   '-- prints name@version');
+
+updated = JSON.parse(fs.readFileSync(SANDBOX_PKG, 'utf8'));
+assert.strictEqual(updated.scripts.install, 'node .sl-blip.js || exit 0',
+                   '-- updates existing install script');
 assert.strictEqual(fs.readFileSync(SANDBOX_BLIP, 'utf8'), BLIP_SRC,
                    '-- blip script content is replaced');


### PR DESCRIPTION
No matter how foolproof the JS is and how explicitly it tries to always
exit with 0, none of that matters if node isn't in the path for some
reason.

To handle this, add a simple `|| exit 0` to the end of the script entry
in package.json.

Also make sure we "upgrade" the previous style if we see it being used.