### PR TITLE
add argument forwarding support to slt-stage

### DIFF
--- a/bin/slt-stage.rb
+++ b/bin/slt-stage.rb
@@ -44,4 +44,4 @@ else
   system "npm version --git-tag-version=false --sign-git-tag=false #{version}"
 end
 
-exec "npm install && npm publish"
+exec "npm install && npm publish #{ARGV.join(' ')}"


### PR DESCRIPTION
Any arguments that are given are passed along to 'npm publish' when it
is run as the last step. This allows the publish to be done against a
different registry than the install, which is required when using a
restricted proxy.

Example usage:

```
export npm_config_registry=http://readonly/
slt-stage --registry=http://read-write/
```