### PR TITLE
prevent publishing of CI related files

### DIFF
--- a/bin/slt-release.sh
+++ b/bin/slt-release.sh
@@ -115,7 +115,7 @@ then
   git checkout "$TAG"
   # npm uses .gitignore if there is no .npmignore, so we'll use that as
   # our starting point if there isn't already a .npmigore file
-  if [[ ! -f ".npmignore" ]]; then
+  if test -f ".gitignore" -a ! -f ".npmignore"; then
     cp .gitignore .npmignore
   fi
   # ignore the entire test tree

--- a/bin/slt-release.sh
+++ b/bin/slt-release.sh
@@ -120,6 +120,7 @@ then
   fi
   # ignore the entire test tree
   echo "test" >> .npmignore
+  echo ".travis.yml" >> .npmignore
   npm publish
   git checkout "$BASE"
 else

--- a/bin/slt-stage.rb
+++ b/bin/slt-stage.rb
@@ -46,11 +46,12 @@ end
 
 # npm uses .gitignore if there is no .npmignore, so we'll use that as
 # our starting point if there isn't already a .npmigore file
-if File.exist?(".npmignore")
-  system("echo test >> .npmignore")
-  system("echo .travis.yml >> .npmignore")
-else
-  system("echo test | cat .gitignore - >> .npmignore")
+if File.exists?(".gitignore") && !File.exist?(".npmignore")
+  IO.copy_stream(".gitignore", ".npmignore")
+end
+open(".npmignore", "a") do |i|
+  i.puts("test")
+  i.puts(".travis.yml")
 end
 
 exec "npm install && npm publish #{ARGV.join(' ')}"

--- a/bin/slt-stage.rb
+++ b/bin/slt-stage.rb
@@ -48,6 +48,7 @@ end
 # our starting point if there isn't already a .npmigore file
 if File.exist?(".npmignore")
   system("echo test >> .npmignore")
+  system("echo .travis.yml >> .npmignore")
 else
   system("echo test | cat .gitignore - >> .npmignore")
 end


### PR DESCRIPTION
There is no value, and some non-zero risk, from distributing CI config files that may contain sensitive information about infrastructure.