### PR TITLE
Allow test folder to be published

### DIFF
--- a/bin/slt-release.sh
+++ b/bin/slt-release.sh
@@ -118,8 +118,10 @@ then
   if test -f ".gitignore" -a ! -f ".npmignore"; then
     cp .gitignore .npmignore
   fi
-  # ignore the entire test tree
-  echo "test" >> .npmignore
+  if test "$(slt info get . publishConfig.export-tests)" != "true"; then
+    # ignore the entire test tree
+    echo "test" >> .npmignore
+  fi
   echo ".travis.yml" >> .npmignore
   npm publish
   git checkout "$BASE"

--- a/bin/slt-stage.rb
+++ b/bin/slt-stage.rb
@@ -50,7 +50,9 @@ if File.exists?(".gitignore") && !File.exist?(".npmignore")
   IO.copy_stream(".gitignore", ".npmignore")
 end
 open(".npmignore", "a") do |i|
-  i.puts("test")
+  if `#{SLT} info get . publishConfig.export-tests`.lines.map(&:strip).last != "true"
+    i.puts("test")
+  end
   i.puts(".travis.yml")
 end
 

--- a/lib/info.js
+++ b/lib/info.js
@@ -12,6 +12,7 @@ var request = require('request');
 module.exports = exports = {
   cli: cli,
   simpleCommand: simpleCommand,
+  get: getCommand,
   name: simpleCommand('name'),
   version: simpleCommand('version'),
   released: releasedCommand,
@@ -22,6 +23,7 @@ exports.cli.out = console.log;
 
 var commands = {
   name: exports.name,
+  get: exports.get,
   released: exports.released,
   version: exports.version,
   repo: exports.repo,
@@ -38,6 +40,12 @@ function cli() {
     console.error('Unknown command: %s', cmd);
     usage('slt info', console.log);
   }
+}
+
+function getCommand(pkgPath, attr) {
+  pkgPath = pkgPath || './';
+  var project = new Project(pkgPath);
+  cli.out(project.get(attr));
 }
 
 function simpleCommand(attr) {
@@ -80,6 +88,7 @@ function usage($0, p) {
   p('');
   p('Commands:');
   p('  name      Print package name');
+  p('  get       Print arbitrary package.json values');
   p('  version   Print package version');
   p('  license   Print normalized package license');
   p('  released  Print latest version on npmjs.org');

--- a/test/test-info.js
+++ b/test/test-info.js
@@ -12,10 +12,14 @@ assert(tools.info.cli, 'info.cli is exported');
 assert(tools.info.name, 'info.name is exported');
 assert(tools.info.version, 'info.version is exported');
 assert(tools.info.repo, 'info.repo is exported');
+assert(tools.info.get, 'info.get is exported');
 
 assertOutput('name', ['.'], 'strong-tools');
 assertOutput('repo', ['.'], 'strongloop/strong-tools');
 assertOutput('version', ['.'], /\d+\.\d+\.\d+/);
+assertOutput('get', ['.', 'name'], 'strong-tools');
+assertOutput('get', ['.', 'bugs.url'],
+             'https://github.com/strongloop/strong-tools/issues');
 
 function assertOutput(fn, args, output) {
   tools.info.cli.out = fmtAssert;


### PR DESCRIPTION
In the rare case that a package _really_ wants to include its `test` folder in its published tarball, this can be done by adding a `publishConfig.export-tests` property in package.json:
```json
{
  "name": "my-package",
  "publishConfig": {
    "export-tests": true
  }
}
```