### PR TITLE
add support for Apache-2.0 license

### DIFF
--- a/bin/slt.ejs
+++ b/bin/slt.ejs
@@ -5,7 +5,7 @@ Commands:
   cla         Create or verify contribution guidelines
   license [F] Set package licensing to standard form F
       Form is auto-detected by default, it can be set explicitly to one of:
-      --mit, --dual-mit, --artistic, --dual-artistic, or --strongloop
+        --mit, --apache, --artistic
   copyright [F..]
               Insert/update copyright headers in JS source files. Uses git for
               copyright years and package.json for license reference.

--- a/lib/APACHE.tpl
+++ b/lib/APACHE.tpl
@@ -1,0 +1,17 @@
+Copyright (c) <%= owner %> <%= years %>. All Rights Reserved.
+Node module: <%= name %>
+
+--------
+Copyright <%= years %> <%= owner %>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/lib/cla.js
+++ b/lib/cla.js
@@ -26,7 +26,7 @@ function ensureCLA(project, log) {
   var pkgRoot = project.rootPath;
   var templatePath = process.env.SLT_CONTRIBUTING;
   var claTpl = _.template(templatePath ? fs.readFileSync(templatePath, 'utf8')
-    : (/MIT|Artistic/.test(project.license()) ? DCO : NO_CONTRIBUTIONS));
+    : (/MIT|Artistic|Apache/.test(project.license()) ? DCO : NO_CONTRIBUTIONS));
   var existingPath = path.resolve(pkgRoot, 'CONTRIBUTING.md');
   var suggestionPath = path.resolve(pkgRoot, 'CONTRIBUTING.md.suggested');
 

--- a/lib/copyright.js
+++ b/lib/copyright.js
@@ -100,6 +100,13 @@ function copyHeader(path, pkg) {
 
 function expandLicense(pkg) {
   var name = _.result(pkg, 'license', pkg);
+  if (/^apache/i.test(name)) {
+    return {
+      template: LICENSED,
+      license: 'Apache License 2.0',
+      ref: 'at https://opensource.org/licenses/Apache-2.0',
+    };
+  }
   if (/^artistic/i.test(name)) {
     return {
       template: LICENSED,

--- a/lib/license.js
+++ b/lib/license.js
@@ -22,6 +22,7 @@ if (process.env.SLT_LICENSE) {
   CUSTOM = fs.readFileSync(process.env.SLT_LICENSE);
 }
 var MIT = fs.readFileSync(require.resolve('./MIT.tpl'));
+var APACHE = fs.readFileSync(require.resolve('./APACHE.tpl'));
 var ARTISTIC = fs.readFileSync(require.resolve('./ARTISTIC.tpl'));
 
 exports.cli = fixCli;
@@ -56,6 +57,13 @@ function fixCli(pkgPath) {
     var license = file.data.license;
 
     switch (setLicense) {
+      case 'apache-2.0':
+      case 'apache-2':
+      case 'apache':
+        file.data.license = 'Apache-2.0';
+        license = writeApacheLicense(file.data);
+        return save();
+
       case 'artistic':
       case 'dual-artistic': // deprecated
         file.data.license = 'Artistic-2.0';
@@ -103,6 +111,14 @@ function fixCli(pkgPath) {
 
     // License string
     switch (license) {
+      case 'Apache-2.0':
+      case 'Apache-2':
+      case 'Apache':
+      case 'apache':
+        file.data.license = 'Apache-2.0';
+        license = writeApacheLicense(file.data);
+        return save();
+
       case '(Artistic-2.0 OR LicenseRef-LICENSE.md)': // OBSOLETE
       case 'Artistic-2.0 OR LicenseRef-LICENSE.md': // OBSOLETE
       case 'Artistic-2.0 OR LicenseRef-LICENSE': // OBSOLETE
@@ -161,6 +177,11 @@ function writeMitLicense(pkg) {
 function writeArtisticLicense(pkg) {
   writeTemplatedLicense('LICENSE.md', 'LICENSE', ARTISTIC, pkg);
   return 'Artistic-2.0';
+}
+
+function writeApacheLicense(pkg) {
+  writeTemplatedLicense('LICENSE', 'LICENSE.md', APACHE, pkg);
+  return 'Apache-2.0';
 }
 
 function writeTemplatedLicense(newName, oldName, text, pkg) {

--- a/lib/license.js
+++ b/lib/license.js
@@ -25,6 +25,7 @@ var MIT = fs.readFileSync(require.resolve('./MIT.tpl'));
 var APACHE = fs.readFileSync(require.resolve('./APACHE.tpl'));
 var ARTISTIC = fs.readFileSync(require.resolve('./ARTISTIC.tpl'));
 
+fixCli.out = console.log;
 exports.cli = fixCli;
 
 function fixCli(pkgPath) {
@@ -43,16 +44,16 @@ function fixCli(pkgPath) {
     process.exit(1);
   }
 
-  copyright.years('.').then(function(actualYears) {
+  return copyright.years('.').then(function(actualYears) {
     if (actualYears.length > 0) {
       years = actualYears.join(',');
     }
-    json(pkgPath, rewrite);
+    return json(pkgPath).catch(function(err) {
+      assert.ifError(err, 'Failed to open ' + pkgPath + ': ' + pkgPath);
+    }).then(rewrite);
   });
 
-  function rewrite(err, file) {
-    assert.ifError(err, 'Failed to open ' + pkgPath + ': ' + pkgPath);
-
+  function rewrite(file) {
     var name = file.data.name;
     var license = file.data.license;
 
@@ -145,17 +146,13 @@ function fixCli(pkgPath) {
         return save();
 
       default:
-        console.log('wrong %s: license unknown %j', name, license);
+        fixCli.out('wrong %s: license unknown %j', name, license);
         process.exit(1);
     }
 
     function save() {
-      console.log('fixed %s: %j to %j', name, license, file.data.license);
-
-      file.save(function(err) {
-        assert.ifError(err);
-        process.exit(0);
-      });
+      fixCli.out('fixed %s: %j to %j', name, license, file.data.license);
+      return file.save();
     }
   }
 }

--- a/test/test-copyright.js
+++ b/test/test-copyright.js
@@ -50,10 +50,19 @@ test('copyright headers', function(t) {
       t.match(header, /at https:.+Artistic-2.0$/);
     });
   });
+  t.test('Apache license', function(t) {
+    var artistic = mockPackage({license: _.constant('Apache')});
+    return copyright.header(__filename, artistic).then(function(header) {
+      testCopyrightStatement(t, header);
+      t.match(header, 'Apache License 2.0');
+      t.match(header, /at https:.+Apache-2.0$/);
+    });
+  });
   t.test('Commercial license', function(t) {
     var custom = mockPackage({license: _.constant('custom')});
     return copyright.header(__filename, custom).then(function(header) {
       testCopyrightStatement(t, header);
+      t.notMatch(header, 'Apache');
       t.notMatch(header, 'Artistic');
       t.notMatch(header, 'MIT');
       t.match(header, 'US Government Users Restricted Rights');

--- a/test/test-license.js
+++ b/test/test-license.js
@@ -1,0 +1,47 @@
+// Copyright IBM Corp. 2014,2016. All Rights Reserved.
+// Node module: strong-tools
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+var assert = require('tapsert');
+var fs = require('fs');
+var path = require('path');
+var rimraf = require('rimraf');
+var tools = require('../');
+
+var SANDBOX = path.resolve(__dirname, 'SANDBOX-lic');
+var SANDBOX_PKG = path.resolve(SANDBOX, 'package.json');
+
+rimraf.sync(SANDBOX);
+fs.mkdirSync(SANDBOX);
+process.chdir(SANDBOX);
+fs.writeFileSync(SANDBOX_PKG, JSON.stringify({name: 'testing'}), 'utf8');
+
+assert(tools.license, 'license is exported');
+
+assert(tools.license.cli, 'license exports a CLI');
+tools.license.cli.out = function() {};
+var original = JSON.parse(fs.readFileSync(SANDBOX_PKG, 'utf8'));
+tools.license.cli('--mit').then(function() {
+  var updated = JSON.parse(fs.readFileSync(SANDBOX_PKG, 'utf8'));
+  assert(original.license !== updated.license,
+         '-- should change license in package');
+  assert.strictEqual(updated.license, 'MIT',
+                     '-- should be set to MIT');
+}).then(function() {
+  return tools.license.cli('--apache').then(function() {
+    var updated = JSON.parse(fs.readFileSync(SANDBOX_PKG, 'utf8'));
+    assert(original.license !== updated.license,
+           '-- should change license in package');
+    assert.strictEqual(updated.license, 'Apache-2.0',
+                       '-- should be set to Apache-2.0');
+  });
+}).then(function() {
+  return tools.license.cli('--artistic').then(function() {
+    var updated = JSON.parse(fs.readFileSync(SANDBOX_PKG, 'utf8'));
+    assert(original.license !== updated.license,
+           '-- should change license in package');
+    assert.strictEqual(updated.license, 'Artistic-2.0',
+                       '-- should be set to Artistic-2.0');
+  });
+});


### PR DESCRIPTION
Add support for doing `slt license --apache` to inject/update a project to use the Apache 2.0 license.

Also adds some basic tests for `slt license` since they were completely missing.