### PR TITLE
add support for TypeScript when updating copyrights

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2014,2016. All Rights Reserved.
+Copyright (c) IBM Corp. 2014,2017. All Rights Reserved.
 Node module: strong-tools
 This project is licensed under the MIT License, full text below.
 

--- a/lib/paths.js
+++ b/lib/paths.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016. All Rights Reserved.
+// Copyright IBM Corp. 2016,2017. All Rights Reserved.
 // Node module: strong-tools
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
@@ -15,13 +15,13 @@ function jsFiles(paths) {
   paths = [].concat(paths);
   var globs = paths.map(function(p) {
     if (/\/$/.test(p)) {
-      p += '**/*.js';
-    } else if (!/[^*]\.js$/.test(p)) {
-      p += '/**/*.js';
+      p += '**/*.{js,ts}';
+    } else if (!/[^*]\.(js|ts)$/.test(p)) {
+      p += '/**/*.{js,ts}';
     }
     return glob(p, {nodir: true, follow: false});
   });
   return Promise.all(globs).then(_.flatten).then(function(paths) {
-    return _.filter(paths, /\.js$/);
+    return _.filter(paths, /\.(js|ts)$/);
   });
 }


### PR DESCRIPTION
Just extends the `**/*.js` filter to `**/*.{js,ts}`.