### PR TITLE
add copyright.owner/identifier support

### DIFF
--- a/lib/copyright.js
+++ b/lib/copyright.js
@@ -89,13 +89,20 @@ function copyHeader(path, pkg) {
   return years.then(function(years) {
     params.years = years.join(',');
     _.defaults(params, {
-      owner: process.env.SLT_OWNER || pkg.get('author.name', 'Owner'),
-      name: pkg.get('name'),
+      owner: copyrightOwner(process.env, pkg),
+      name: pkg.get('copyright.identifier', pkg.get('name')),
       license: pkg.get('license'),
     });
     return params.template(params);
   });
 }
+
+function copyrightOwner(env, pkg) {
+  return env.SLT_OWNER ||
+    pkg.get('copyright.owner') ||
+      pkg.get('author.name', 'Owner');
+}
+
 
 function expandLicense(pkg) {
   var name = _.result(pkg, 'license', pkg);


### PR DESCRIPTION
The copyright.owner and copyright.identifier properties can be supplied
in the package's package.json to override the use of author and package
name in copyright statements.