### PR TITLE
feat: bump versions in lock files if present

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,12 @@
 {
-  "extends": "strongloop"
+  "extends": "strongloop",
+  "rules": {
+    "indent": ["error", 2, {
+      "CallExpression": {
+        "arguments": "off"
+      },
+      "MemberExpression": "off",
+      "SwitchCase": 1
+    }]
+  }
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 language: node_js
 node_js:
-  - "7"
+  - "8"
   - "6"
   - "4"
 git:
   depth: 10000 # need the whole thing
-after_script:
-  - "./node_modules/.bin/tap --coverage --coverage-report=text-lcov | ./node_modules/.bin/codacy-coverage"

--- a/bin/slt-release.sh
+++ b/bin/slt-release.sh
@@ -17,8 +17,11 @@ used.
 
 What slt-release will do:
  - generate a CHANGES.md file
- - increment package version in package.json and bower.json (if present)
- - commit CHANGES.md, package.json, bower.json, and npm-shrinkwrap.json
+ - increment package version in package metadata files (when present):
+    - package.json, bower.json, npm-shrinkwrap.json, package-lock.json
+ - commit CHANGES.md, package.json
+    - also commit bower.json, npm-shrinkwrap.json, package-lock.json
+      if present
  - tag commit with an annotated tag
  - merge tag back in to base branch
    - IF npm-shrinkwrap.json was not previously part of that branch then
@@ -125,7 +128,7 @@ echo "Updating package version to $V"
 slt version set "$V"
 
 echo "Committing package and CHANGES for v$V"
-TO_ADD="$(git ls-files bower.json) package.json CHANGES.md"
+TO_ADD="$(git ls-files bower.json package-lock.json) package.json CHANGES.md"
 TO_REMOVE=""
 if [ -e npm-shrinkwrap.json ]; then
   if ! git cat-file -e "$BASE":npm-shrinkwrap.json; then

--- a/lib/license.js
+++ b/lib/license.js
@@ -9,7 +9,6 @@ var Promise = require('bluebird');
 var _ = require('lodash');
 var assert = require('assert');
 var copyright = require('./copyright');
-var debug = require('debug')('strong-tools:fix-license');
 var fs = require('fs');
 var git = require('./git');
 var json = require('json-file-plus');
@@ -31,7 +30,6 @@ exports.cli = fixCli;
 
 function fixCli(pkgPath) {
   pkgPath = pkgPath || 'package.json';
-  debug(pkgPath);
   var setLicense = pkgPath.match(/^--(.*)/);
   if (setLicense) {
     pkgPath = 'package.json';
@@ -87,8 +85,6 @@ function fixCli(pkgPath) {
       console.error('%s: no license property!', name);
       process.exit(1);
     }
-
-    debug('license: %j', license);
 
     // License object
     switch (license.name) {

--- a/lib/project.js
+++ b/lib/project.js
@@ -41,12 +41,28 @@ function Project(pkgPath, cb) {
   }
 
   this.bowerJSONPath = path.resolve(this.rootPath, 'bower.json');
+  this.shrinkwrapJSONPath = path.resolve(this.rootPath, 'npm-shrinkwrap.json');
+  this.packageLockJSONPath = path.resolve(this.rootPath, 'package-lock.json');
 
   // test for bower.json existence
   try {
     this.rawBowerJSON = JSON.parse(fs.readFileSync(this.bowerJSONPath, 'utf8'));
   } catch (e) {
     this.rawBowerJSON = null;
+  }
+
+  try {
+    this.rawShrinkwrapJSON = JSON.parse(
+      fs.readFileSync(this.shrinkwrapJSONPath, 'utf8'));
+  } catch (e) {
+    this.rawShrinkwrapJSON = null;
+  }
+
+  try {
+    this.rawPackageLockJSON = JSON.parse(
+      fs.readFileSync(this.packageLockJSONPath, 'utf8'));
+  } catch (e) {
+    this.rawPackageLockJSON = null;
   }
 
   try {
@@ -135,6 +151,14 @@ function Project$version(v) {
       this.rawBowerJSON.version = v;
     }
 
+    if (this.rawShrinkwrapJSON) {
+      this.rawShrinkwrapJSON.version = v;
+    }
+
+    if (this.rawPackageLockJSON) {
+      this.rawPackageLockJSON.version = v;
+    }
+
     this.normalizedPkgJSON = normalize(this.rawPkgJSON);
     return v;
   } else {
@@ -150,10 +174,24 @@ function Project$persist() {
   var newJSON = JSON.stringify(this.rawPkgJSON, null, 2) + '\n';
   fs.writeFileSync(this.pkgJSONPath, newJSON);
 
-  // write bower json if necessary
+  // re-write bower.json if necessary
   if (this.rawBowerJSON) {
     var newBowerJSON = JSON.stringify(this.rawBowerJSON, null, 2) + '\n';
     fs.writeFileSync(this.bowerJSONPath, newBowerJSON);
+  }
+
+  // re-write npm-shrinkwrap.json if necessary
+  if (this.rawShrinkwrapJSON) {
+    var newShrinkwrapJSON =
+      JSON.stringify(this.rawShrinkwrapJSON, null, 2) + '\n';
+    fs.writeFileSync(this.shrinkwrapJSONPath, newShrinkwrapJSON);
+  }
+
+  // re-write package-lock.json if necessary
+  if (this.rawPackageLockJSON) {
+    var newPackageLockJSON =
+      JSON.stringify(this.rawPackageLockJSON, null, 2) + '\n';
+    fs.writeFileSync(this.packageLockJSONPath, newPackageLockJSON);
   }
 }
 

--- a/lib/shrinkwrap.js
+++ b/lib/shrinkwrap.js
@@ -6,7 +6,6 @@
 'use strict';
 
 var _ = require('lodash');
-var debug = require('debug')('strong-tools:fix-license');
 var json = require('json-file-plus');
 var path = require('path');
 
@@ -15,7 +14,6 @@ exports.cli = updateShrinkwrap;
 
 function updateShrinkwrap(shrinkwrap) {
   shrinkwrap = path.resolve(shrinkwrap || 'npm-shrinkwrap.json');
-  debug(shrinkwrap);
 
   return json(shrinkwrap).then(rewrite).then(function() {
     updateShrinkwrap.out('removed resolution URLs from %s', shrinkwrap);

--- a/lib/wrapped.js
+++ b/lib/wrapped.js
@@ -17,7 +17,7 @@ function wrapped(path) {
       return require('module')._load(
         path, // path
         null, // parent
-        true  // isMain
+        true // isMain
       );
     },
   };

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   "homepage": "https://github.com/strongloop/strong-tools",
   "dependencies": {
     "bluebird": "^3.1.1",
-    "debug": "^2.2.0",
     "gift": "^0.10.0",
     "glob": "^7.0.3",
     "json-file-plus": "^3.0.1",
@@ -44,8 +43,7 @@
     "node": ">=4"
   },
   "devDependencies": {
-    "codacy-coverage": "^2.0.0",
-    "eslint": "^3.14.1",
+    "eslint": "^4.6.1",
     "eslint-config-strongloop": "^2",
     "mkdirp": "^0.5.1",
     "rimraf": "^2.2.8",

--- a/test/test-project.js
+++ b/test/test-project.js
@@ -16,6 +16,8 @@ var Project = require('../lib/project');
 var SANDBOX = path.resolve(__dirname, 'SANDBOX-project');
 var SANDBOX_PKG = path.resolve(SANDBOX, 'package.json');
 var SANDBOX_BOWER = path.resolve(SANDBOX, 'bower.json');
+var SANDBOX_SHRINKWRAP = path.resolve(SANDBOX, 'npm-shrinkwrap.json');
+var SANDBOX_PACKAGE_LOCK = path.resolve(SANDBOX, 'package-lock.json');
 
 test('setup', function(t) {
   helpers.resetSandboxSync(t, SANDBOX, SANDBOX_PKG, {
@@ -140,6 +142,32 @@ test('bower support', function(t) {
   var bower = JSON.parse(fs.readFileSync(SANDBOX_BOWER, 'utf8'));
   t.strictEqual(p1.version(), '2.3.4');
   t.strictEqual(bower.version, '2.3.4');
+  t.end();
+});
+
+test('package-lock support', function(t) {
+  var pkgjson = JSON.parse(fs.readFileSync(SANDBOX_PKG, 'utf8'));
+  fs.writeFileSync(SANDBOX_PACKAGE_LOCK, JSON.stringify(pkgjson), 'utf8');
+  var p1 = new Project(SANDBOX);
+  t.strictEqual(p1.version(), '2.3.4');
+  p1.version('4.5.6');
+  p1.persist();
+  var pkgLock = JSON.parse(fs.readFileSync(SANDBOX_PACKAGE_LOCK, 'utf8'));
+  t.strictEqual(p1.version(), '4.5.6');
+  t.strictEqual(pkgLock.version, '4.5.6');
+  t.end();
+});
+
+test('shrinkwrap support', function(t) {
+  var pkgjson = JSON.parse(fs.readFileSync(SANDBOX_PKG, 'utf8'));
+  fs.writeFileSync(SANDBOX_SHRINKWRAP, JSON.stringify(pkgjson), 'utf8');
+  var p1 = new Project(SANDBOX);
+  t.strictEqual(p1.version(), '4.5.6');
+  p1.version('3.4.5');
+  p1.persist();
+  var shrinkwrap = JSON.parse(fs.readFileSync(SANDBOX_SHRINKWRAP, 'utf8'));
+  t.strictEqual(p1.version(), '3.4.5');
+  t.strictEqual(shrinkwrap.version, '3.4.5');
   t.end();
 });
 


### PR DESCRIPTION
It is nice when the version number in package.json matches the version
numbers in package-lock.json and npm-shrinkwrap.json when they are being
used. They should be treated the same way bower.json is treated.

Resolves #83